### PR TITLE
feat: Implement milestone recording (#40)

### DIFF
--- a/contracts/shipment/src/errors.rs
+++ b/contracts/shipment/src/errors.rs
@@ -11,4 +11,5 @@ pub enum Error {
     CounterOverflow = 5,
     ShipmentNotFound = 6,
     CarrierNotAuthorized = 7,
+    InvalidStatus = 8,
 }

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -224,4 +224,45 @@ impl NavinShipment {
 
         Ok(())
     }
+
+    /// Record a milestone for a shipment.
+    /// Only registered carriers can record milestones.
+    pub fn record_milestone(
+        env: Env,
+        carrier: Address,
+        shipment_id: u64,
+        checkpoint: Symbol,
+        data_hash: BytesN<32>,
+    ) -> Result<(), SdkError> {
+        require_initialized(&env)?;
+        carrier.require_auth();
+        require_role(&env, &carrier, Role::Carrier)?;
+
+        // Verify shipment exists and status
+        let shipment =
+            storage::get_shipment(&env, shipment_id).ok_or(SdkError::from_contract_error(6))?;
+
+        if shipment.status != ShipmentStatus::InTransit {
+            return Err(SdkError::from_contract_error(8));
+        }
+
+        let timestamp = env.ledger().timestamp();
+
+        let _milestone = Milestone {
+            shipment_id,
+            checkpoint: checkpoint.clone(),
+            data_hash: data_hash.clone(),
+            timestamp,
+            reporter: carrier.clone(),
+        };
+
+        // Do NOT store the milestone on-chain
+        // Emit the milestone_recorded event (Hash-and-Emit pattern)
+        env.events().publish(
+            (Symbol::new(&env, "milestone_recorded"),),
+            (shipment_id, checkpoint, data_hash, carrier),
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Description
Fixes #[40](https://github.com/Navin-xmr/navin-contracts/issues/40)

This PR implements the [record_milestone](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/lib.rs:227:4-266:5) functionality for the [shipment](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/lib.rs:193:4-197:5) contract. This enables registered carriers to report shipment checkpoints by publishing the `milestone_recorded` event using the **Hash-and-Emit** pattern to save on-chain storage costs.

### Tasks Completed:
- Added the `InvalidStatus` state enum member to the [errors.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/errors.rs:0:0-0:0).
- Implemented [record_milestone](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/lib.rs:227:4-266:5) function in [contracts/shipment/src/lib.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/lib.rs:0:0-0:0).
- Enforced Role-based Access Control (RBAC) ensuring only `Role::Carrier` can record a milestone.
- Validated that the shipment actually exists using `storage::get_shipment` and verified the status is perfectly `ShipmentStatus::InTransit`.
- Verified the `milestone_recorded` event structure aligns with the business requirements [(shipment_id, checkpoint, data_hash, reporter)](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/example-contract/src/lib.rs:31:4-45:5).

### Testing Strategy & Acceptance Criteria
The modifications are fully covered by 3 specific unit tests under [contracts/shipment/src/test.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/test.rs:0:0-0:0):
- **[test_record_milestone_success](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/test.rs:388:0-420:1)**: Manually steps up the status to `InTransit` and ensures the milestone passes without throwing an error and the event effectively publishes onto the ledger.
- **[test_record_milestone_wrong_status](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/test.rs:422:0-440:1)**: Creates a new shipment and attempts to fire the event immediately (while the shipment is still flagged as `Created`), confirming it hits the expected `Contract Error(8)`.
- **[test_record_milestone_unauthorized](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/test.rs:442:0-467:1)**: Validates that random addresses invoking the function will panic and fail with `CarrierNotAuthorized`.

### PR Checklist:
- [x] [record_milestone](cci:1://file:///home/edohwares/Desktop/Room/drips/navin-contracts/contracts/shipment/src/lib.rs:227:4-266:5) implemented
- [x] At least 3 unit tests covering success, wrong status, and unauthorized accesses
- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass
- [x] `cargo build --target wasm32-unknown-unknown --release` — WASM builds 

Closes #40 