### PR TITLE
test(shipment): add create_shipment uninitialized contract test

### DIFF
--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -2568,3 +2568,22 @@ fn test_get_contract_metadata_after_creating_shipments() {
     assert_eq!(meta.shipment_count, 2);
     assert!(meta.initialized);
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_create_shipment_fails_before_initialization() {
+    let (env, client, _admin, _token_contract) = setup_env();
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+    // Contract not initialized — should panic with NotInitialized (#2)
+    client.create_shipment(
+        &sender,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+    );
+}


### PR DESCRIPTION
**Summary**

Adds the missing test case for `create_shipment` on an uninitialized contract, completing the acceptance criteria for issue #51.

Most of the required tests already existed in `test.rs`:
`test_create_shipment_success` — valid Company role
 `test_create_shipment_unauthorized` — unauthorized caller
 `test_multiple_shipments_have_unique_ids` — sequential IDs
 `test_create_shipment_success` / geofence tests — event emission

 The one gap was an explicit test calling `create_shipment` before `initialize`, expecting `Error(Contract, #2)`. This PR adds `test_create_shipment_fails_before_initialization` to cover that case.

 Note: The "zero-length hash" task is not applicable — `BytesN<32>` enforces a fixed 32-byte size at compile time, making it impossible to pass an invalid-length hash.

 **Changes**
 Added `test_create_shipment_fails_before_initialization` to `contracts/shipment/src/test.rs`

 **Testing**
 `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` ✅
 `cargo test` ✅
`cargo build --target wasm32-unknown-unknown --release` ✅

 Closes #51