### PR TITLE
Implement governance token integration and snapshot voting

### DIFF
--- a/contracts/shipment/src/errors.rs
+++ b/contracts/shipment/src/errors.rs
@@ -76,4 +76,10 @@ pub enum NavinError {
     ShipmentLimitReached = 30,
     /// Invalid configuration parameters provided.
     InvalidConfig = 31,
+    /// Proposer's token balance (or delegated balance) is below min_proposal_tokens.
+    InsufficientProposalTokens = 32,
+    /// Approver cannot vote because their tokens are locked from a prior approval.
+    VoteLockActive = 33,
+    /// Approver had no voting power at the proposal's snapshot.
+    NoVotingPowerAtSnapshot = 34,
 }

--- a/contracts/shipment/src/storage.rs
+++ b/contracts/shipment/src/storage.rs
@@ -985,3 +985,51 @@ pub fn is_shipment_archived(env: &Env, shipment_id: u64) -> bool {
         .temporary()
         .has(&DataKey::ArchivedShipment(shipment_id))
 }
+
+// ============= Governance / Snapshot Voting Storage =============
+
+/// Get snapshot balance for an address for a proposal. Returns None if not set.
+pub fn get_snapshot_balance(env: &Env, proposal_id: u64, address: &Address) -> Option<i128> {
+    let key = DataKey::SnapshotBalance(proposal_id, address.clone());
+    env.storage().instance().get(&key)
+}
+
+/// Set snapshot balance for an address for a proposal.
+pub fn set_snapshot_balance(env: &Env, proposal_id: u64, address: &Address, amount: i128) {
+    let key = DataKey::SnapshotBalance(proposal_id, address.clone());
+    env.storage().instance().set(&key, &amount);
+}
+
+/// Get delegator for a delegatee. Returns None if no delegation is set.
+pub fn get_delegation(env: &Env, delegatee: &Address) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Delegation(delegatee.clone()))
+}
+
+/// Set delegation: delegatee -> delegator.
+pub fn set_delegation(env: &Env, delegatee: &Address, delegator: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Delegation(delegatee.clone()), delegator);
+}
+
+/// Get vote lock until ledger for (address, proposal_id). Returns None if not locked.
+pub fn get_vote_lock(env: &Env, address: &Address, proposal_id: u64) -> Option<u32> {
+    env.storage()
+        .instance()
+        .get(&DataKey::VoteLock(address.clone(), proposal_id))
+}
+
+/// Set vote lock: lock until the given ledger.
+pub fn set_vote_lock(env: &Env, address: &Address, proposal_id: u64, until_ledger: u32) {
+    env.storage().instance().set(
+        &DataKey::VoteLock(address.clone(), proposal_id),
+        &until_ledger,
+    );
+}
+
+/// Get voting power at snapshot for a proposal and address. Returns snapshot balance if set, else 0.
+pub fn get_voting_power_at_snapshot(env: &Env, proposal_id: u64, address: &Address) -> i128 {
+    get_snapshot_balance(env, proposal_id, address).unwrap_or(0)
+}

--- a/contracts/shipment/src/types.rs
+++ b/contracts/shipment/src/types.rs
@@ -57,6 +57,12 @@ pub enum DataKey {
     ActiveShipmentCount(Address),
     /// Contract configuration parameters.
     ContractConfig,
+    /// Vote lock: (address, proposal_id) -> lock until ledger.
+    VoteLock(Address, u64),
+    /// Delegation: delegatee -> delegator address (delegatee's voting power includes delegator's balance).
+    Delegation(Address),
+    /// Snapshot balance for a proposal: (proposal_id, address) -> i128 balance at snapshot.
+    SnapshotBalance(u64, Address),
     /// Event counter for a shipment (tracks number of events emitted).
     EventCount(u64),
     /// Archived shipment data in temporary storage (for terminal state shipments).
@@ -363,6 +369,8 @@ pub struct Proposal {
     pub expires_at: u64,
     /// Whether the proposal has been executed.
     pub executed: bool,
+    /// Ledger at which voting power was snapshotted for this proposal (0 = legacy/no snapshot).
+    pub snapshot_ledger: u32,
 }
 
 /// Notification types for backend indexing and push notifications.

--- a/contracts/shipment/test_snapshots/e2e_test/test_debug_event_structure.1.json
+++ b/contracts/shipment/test_snapshots/e2e_test/test_debug_event_structure.1.json
@@ -587,10 +587,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -639,6 +656,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/e2e_test/test_e2e_cancel_refund_path_with_token_balances.1.json
+++ b/contracts/shipment/test_snapshots/e2e_test/test_e2e_cancel_refund_path_with_token_balances.1.json
@@ -832,10 +832,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -884,6 +901,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/e2e_test/test_e2e_deadline_expiry_auto_cancel_and_refund.1.json
+++ b/contracts/shipment/test_snapshots/e2e_test/test_e2e_deadline_expiry_auto_cancel_and_refund.1.json
@@ -777,10 +777,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -829,6 +846,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/e2e_test/test_e2e_happy_path_with_milestones_and_token_balances.1.json
+++ b/contracts/shipment/test_snapshots/e2e_test/test_e2e_happy_path_with_milestones_and_token_balances.1.json
@@ -1212,10 +1212,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -1264,6 +1281,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/e2e_test/test_e2e_partial_milestones_then_cancel_via_deadline.1.json
+++ b/contracts/shipment/test_snapshots/e2e_test/test_e2e_partial_milestones_then_cancel_via_deadline.1.json
@@ -1102,10 +1102,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -1154,6 +1171,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/stress_test/test_20_concurrent_status_updates.1.json
+++ b/contracts/shipment/test_snapshots/stress_test/test_20_concurrent_status_updates.1.json
@@ -7743,10 +7743,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -7795,6 +7812,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/stress_test/test_create_50_shipments_sequentially.1.json
+++ b/contracts/shipment/test_snapshots/stress_test/test_create_50_shipments_sequentially.1.json
@@ -12434,10 +12434,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -12486,6 +12503,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/stress_test/test_no_data_corruption_between_shipments.1.json
+++ b/contracts/shipment/test_snapshots/stress_test/test_no_data_corruption_between_shipments.1.json
@@ -14943,10 +14943,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -14995,6 +15012,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/stress_test/test_verify_shipment_count_after_mass_operations.1.json
+++ b/contracts/shipment/test_snapshots/stress_test/test_verify_shipment_count_after_mass_operations.1.json
@@ -18561,10 +18561,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -18613,6 +18630,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_active_shipment_count_tracking.1.json
+++ b/contracts/shipment/test_snapshots/test/test_active_shipment_count_tracking.1.json
@@ -731,10 +731,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -783,6 +800,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_add_carrier_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_add_carrier_returns_unauthorized.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_add_carrier_to_whitelist.1.json
+++ b/contracts/shipment/test_snapshots/test/test_add_carrier_to_whitelist.1.json
@@ -209,10 +209,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -261,6 +278,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_add_carrier_to_whitelist_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_add_carrier_to_whitelist_returns_unauthorized.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_add_company_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_add_company_returns_unauthorized.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_admin_is_stored_correctly.1.json
+++ b/contracts/shipment/test_snapshots/test/test_admin_is_stored_correctly.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_analytics_batch_and_cancel.1.json
+++ b/contracts/shipment/test_snapshots/test/test_analytics_batch_and_cancel.1.json
@@ -998,10 +998,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -1050,6 +1067,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_analytics_counters.1.json
+++ b/contracts/shipment/test_snapshots/test/test_analytics_counters.1.json
@@ -626,10 +626,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -678,6 +695,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_already_approved.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_already_approved.1.json
@@ -248,6 +248,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -340,10 +348,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -392,6 +417,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_not_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_not_admin.1.json
@@ -248,6 +248,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -340,10 +348,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -392,6 +417,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_returns_already_approved.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_returns_already_approved.1.json
@@ -443,6 +443,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -719,10 +727,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -771,6 +796,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_returns_not_an_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_returns_not_an_admin.1.json
@@ -415,6 +415,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -688,10 +696,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -740,6 +765,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_returns_proposal_expired.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_returns_proposal_expired.1.json
@@ -415,6 +415,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -688,10 +696,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -740,6 +765,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_returns_proposal_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_returns_proposal_not_found.1.json
@@ -198,10 +198,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -250,6 +267,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_approve_action_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_approve_action_success.1.json
@@ -276,6 +276,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -371,10 +379,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -423,6 +448,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_active_shipment_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_active_shipment_fails.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_cancelled_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_cancelled_shipment.1.json
@@ -564,10 +564,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -616,6 +633,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_delivered_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_delivered_shipment.1.json
@@ -686,10 +686,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -738,6 +755,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_disputed_shipment_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_disputed_shipment_fails.1.json
@@ -586,10 +586,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -638,6 +655,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_in_transit_shipment_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_in_transit_shipment_fails.1.json
@@ -561,10 +561,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -613,6 +630,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_nonexistent_shipment_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_nonexistent_shipment_fails.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_archive_shipment_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_archive_shipment_unauthorized.1.json
@@ -509,10 +509,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -561,6 +578,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_batch_limit_reached.1.json
+++ b/contracts/shipment/test_snapshots/test/test_batch_limit_reached.1.json
@@ -224,10 +224,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -276,6 +293,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_by_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_by_admin.1.json
@@ -487,10 +487,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -539,6 +556,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_delivered_should_fail.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_delivered_should_fail.1.json
@@ -431,10 +431,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -483,6 +500,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_disputed_should_fail.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_disputed_should_fail.1.json
@@ -431,10 +431,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -483,6 +500,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_returns_unauthorized.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_with_escrow.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_with_escrow.1.json
@@ -482,10 +482,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -534,6 +551,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_cancel_shipment_without_escrow.1.json
+++ b/contracts/shipment/test_snapshots/test/test_cancel_shipment_without_escrow.1.json
@@ -454,10 +454,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -506,6 +523,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_breach_event_emitted_alongside_condition_breach.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_breach_event_emitted_alongside_condition_breach.1.json
@@ -515,10 +515,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -567,6 +584,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_breach_event_emitted_on_report_condition_breach.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_breach_event_emitted_on_report_condition_breach.1.json
@@ -515,10 +515,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -567,6 +584,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_dispute_loss_event_contains_correct_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_dispute_loss_event_contains_correct_carrier.1.json
@@ -543,10 +543,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -595,6 +612,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_dispute_loss_event_emitted_on_refund_to_company.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_dispute_loss_event_emitted_on_refund_to_company.1.json
@@ -543,10 +543,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -595,6 +612,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_dispute_loss_not_emitted_when_carrier_wins.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_dispute_loss_not_emitted_when_carrier_wins.1.json
@@ -543,10 +543,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -595,6 +612,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_handoff_completed_event.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_handoff_completed_event.1.json
@@ -566,10 +566,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -618,6 +635,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_late_delivery_event_and_milestones.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_late_delivery_event_and_milestones.1.json
@@ -732,10 +732,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -784,6 +801,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_carrier_on_time_delivery_event.1.json
+++ b/contracts/shipment/test_snapshots/test/test_carrier_on_time_delivery_event.1.json
@@ -658,10 +658,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -710,6 +727,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_check_deadline_fails_if_not_expired.1.json
+++ b/contracts/shipment/test_snapshots/test/test_check_deadline_fails_if_not_expired.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_check_deadline_returns_not_expired.1.json
+++ b/contracts/shipment/test_snapshots/test/test_check_deadline_returns_not_expired.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_check_deadline_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_check_deadline_returns_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_check_deadline_success_auto_cancels_and_refunds.1.json
+++ b/contracts/shipment/test_snapshots/test/test_check_deadline_success_auto_cancels_and_refunds.1.json
@@ -458,10 +458,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -510,6 +527,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_confirm_delivery_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_confirm_delivery_returns_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_confirm_delivery_success_at_checkpoint.1.json
+++ b/contracts/shipment/test_snapshots/test/test_confirm_delivery_success_at_checkpoint.1.json
@@ -500,10 +500,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -552,6 +569,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_confirm_delivery_success_in_transit.1.json
+++ b/contracts/shipment/test_snapshots/test/test_confirm_delivery_success_in_transit.1.json
@@ -501,10 +501,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -553,6 +570,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_confirm_delivery_wrong_receiver.1.json
+++ b/contracts/shipment/test_snapshots/test/test_confirm_delivery_wrong_receiver.1.json
@@ -430,10 +430,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -482,6 +499,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_confirm_delivery_wrong_status.1.json
+++ b/contracts/shipment/test_snapshots/test/test_confirm_delivery_wrong_status.1.json
@@ -430,10 +430,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -482,6 +499,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_count_decrements_on_cancel.1.json
+++ b/contracts/shipment/test_snapshots/test/test_count_decrements_on_cancel.1.json
@@ -455,10 +455,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -507,6 +524,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_count_decrements_on_deadline_expiration.1.json
+++ b/contracts/shipment/test_snapshots/test/test_count_decrements_on_deadline_expiration.1.json
@@ -431,10 +431,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -483,6 +500,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_count_decrements_on_delivery.1.json
+++ b/contracts/shipment/test_snapshots/test/test_count_decrements_on_delivery.1.json
@@ -617,10 +617,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -669,6 +686,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_count_decrements_on_dispute_resolution.1.json
+++ b/contracts/shipment/test_snapshots/test/test_count_decrements_on_dispute_resolution.1.json
@@ -662,10 +662,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -714,6 +731,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipment_returns_counter_overflow.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipment_returns_counter_overflow.1.json
@@ -170,10 +170,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -222,6 +239,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipment_returns_invalid_hash.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipment_returns_invalid_hash.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipment_returns_shipment_limit_reached.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipment_returns_shipment_limit_reached.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipment_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipment_success.1.json
@@ -430,10 +430,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -482,6 +499,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipment_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipment_unauthorized.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipments_batch_invalid_input.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipments_batch_invalid_input.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipments_batch_oversized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipments_batch_oversized.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipments_batch_returns_shipment_limit_reached.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipments_batch_returns_shipment_limit_reached.1.json
@@ -224,10 +224,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -276,6 +293,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_create_shipments_batch_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_create_shipments_batch_success.1.json
@@ -1482,10 +1482,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -1534,6 +1551,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_delivery_before_deadline.1.json
+++ b/contracts/shipment/test_snapshots/test/test_delivery_before_deadline.1.json
@@ -632,10 +632,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -684,6 +701,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_delivery_success_event_contains_correct_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_delivery_success_event_contains_correct_carrier.1.json
@@ -630,10 +630,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -682,6 +699,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_delivery_success_event_emitted_on_confirm_delivery.1.json
+++ b/contracts/shipment/test_snapshots/test/test_delivery_success_event_emitted_on_confirm_delivery.1.json
@@ -630,10 +630,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -682,6 +699,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_invalid_amount.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_invalid_amount.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_escrow_already_deposited.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_escrow_already_deposited.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_invalid_amount_negative.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_invalid_amount_negative.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_invalid_amount_zero.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_invalid_amount_zero.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_invalid_status.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_returns_invalid_status.1.json
@@ -430,10 +430,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -482,6 +499,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_success.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_deposit_escrow_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_deposit_escrow_unauthorized.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_cancel_path_create_deposit_cancel_refund.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_cancel_path_create_deposit_cancel_refund.1.json
@@ -482,10 +482,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -534,6 +551,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_deposit_after_status_change_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_deposit_after_status_change_fails.1.json
@@ -561,10 +561,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -613,6 +630,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_dispute_resolve_to_cancelled.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_dispute_resolve_to_cancelled.1.json
@@ -686,10 +686,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -738,6 +755,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_dispute_resolve_to_delivered.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_dispute_resolve_to_delivered.1.json
@@ -686,10 +686,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -738,6 +755,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_double_deposit_prevention.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_double_deposit_prevention.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_happy_path_create_deposit_transit_deliver_confirm.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_happy_path_create_deposit_transit_deliver_confirm.1.json
@@ -691,10 +691,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -743,6 +760,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_refund_after_delivery_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_refund_after_delivery_fails.1.json
@@ -659,10 +659,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -711,6 +728,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_escrow_release_without_delivery_confirm_from_created_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_escrow_release_without_delivery_confirm_from_created_fails.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_after_create.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_after_create.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_after_delivery.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_after_delivery.1.json
@@ -631,10 +631,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -683,6 +700,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_after_milestone.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_after_milestone.1.json
@@ -589,10 +589,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -641,6 +658,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_after_status_updates.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_after_status_updates.1.json
@@ -593,10 +593,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -645,6 +662,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_returns_zero_for_new_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_returns_zero_for_new_shipment.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_event_count_with_multiple_milestones.1.json
+++ b/contracts/shipment/test_snapshots/test/test_event_count_with_multiple_milestones.1.json
@@ -645,10 +645,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -697,6 +714,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_already_executed.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_already_executed.1.json
@@ -273,6 +273,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -365,10 +373,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -417,6 +442,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_auto_on_threshold.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_auto_on_threshold.1.json
@@ -276,6 +276,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -371,10 +379,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -423,6 +448,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_insufficient_approvals.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_insufficient_approvals.1.json
@@ -251,6 +251,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -346,10 +354,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -398,6 +423,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_insufficient_approvals.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_insufficient_approvals.1.json
@@ -418,6 +418,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -694,10 +702,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -746,6 +771,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_proposal_already_executed.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_proposal_already_executed.1.json
@@ -440,6 +440,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -713,10 +721,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -765,6 +790,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_proposal_expired.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_proposal_expired.1.json
@@ -440,6 +440,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -713,10 +721,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -765,6 +790,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_proposal_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_execute_proposal_returns_proposal_not_found.1.json
@@ -198,10 +198,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -250,6 +267,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_force_refund_action.1.json
+++ b/contracts/shipment/test_snapshots/test/test_force_refund_action.1.json
@@ -435,6 +435,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -708,10 +716,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -760,6 +785,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_force_release_action.1.json
+++ b/contracts/shipment/test_snapshots/test/test_force_release_action.1.json
@@ -435,6 +435,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -708,10 +716,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -760,6 +785,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_full_shipment_lifecycle_integration.1.json
+++ b/contracts/shipment/test_snapshots/test/test_full_shipment_lifecycle_integration.1.json
@@ -859,10 +859,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -911,6 +928,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_contract_metadata_after_creating_shipments.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_contract_metadata_after_creating_shipments.1.json
@@ -674,10 +674,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -726,6 +743,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_contract_metadata_after_init.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_contract_metadata_after_init.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_contract_metadata_after_upgrade.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_contract_metadata_after_upgrade.1.json
@@ -170,10 +170,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -222,6 +239,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_escrow_balance_after_deposit.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_escrow_balance_after_deposit.1.json
@@ -478,10 +478,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -530,6 +547,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_escrow_balance_after_release.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_escrow_balance_after_release.1.json
@@ -432,10 +432,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -484,6 +501,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_escrow_balance_returns_zero_without_deposit.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_escrow_balance_returns_zero_without_deposit.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_escrow_balance_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_escrow_balance_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_proposal_returns_proposal_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_proposal_returns_proposal_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_role_assigned.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_role_assigned.1.json
@@ -225,10 +225,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -277,6 +294,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_role_unassigned.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_role_unassigned.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_shipment_count_after_creating_shipments.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_shipment_count_after_creating_shipments.1.json
@@ -921,10 +921,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -973,6 +990,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_shipment_count_returns_zero_after_initialization.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_shipment_count_returns_zero_after_initialization.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_shipment_returns_correct_data.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_shipment_returns_correct_data.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_get_version_after_upgrade.1.json
+++ b/contracts/shipment/test_snapshots/test/test_get_version_after_upgrade.1.json
@@ -170,10 +170,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -222,6 +239,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_governance_delegation_delegatee_has_delegator_balance_at_snapshot.1.json
+++ b/contracts/shipment/test_snapshots/test/test_governance_delegation_delegatee_has_delegator_balance_at_snapshot.1.json
@@ -1,0 +1,1067 @@
+{
+  "generators": {
+    "address": 7,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "init_multisig",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "update_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "batch_operation_limit"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "default_shipment_limit"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "governance_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_metadata_entries"
+                      },
+                      "val": {
+                        "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_proposal_tokens"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 50
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_status_update_interval"
+                      },
+                      "val": {
+                        "u64": 60
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_max_admins"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_min_admins"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposal_expiry_seconds"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_extension"
+                      },
+                      "val": {
+                        "u32": 518400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_threshold"
+                      },
+                      "val": {
+                        "u32": 17280
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "vote_lock_ledgers"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "set_delegation",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "propose_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "TransferAdmin"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 500
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GovToken"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GOV"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalSupply"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000500
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Proposal"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Proposal"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "action"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "TransferAdmin"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "approvals"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminList"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContractConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "batch_operation_limit"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "default_shipment_limit"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "max_metadata_entries"
+                              },
+                              "val": {
+                                "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 50
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_status_update_interval"
+                              },
+                              "val": {
+                                "u64": 60
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_max_admins"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_min_admins"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_expiry_seconds"
+                              },
+                              "val": {
+                                "u64": 604800
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_extension"
+                              },
+                              "val": {
+                                "u32": 518400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_threshold"
+                              },
+                              "val": {
+                                "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Delegation"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ProposalCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentLimit"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 500
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 500
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/shipment/test_snapshots/test/test_governance_get_proposal_snapshot_ledger_returns_ledger_at_creation.1.json
+++ b/contracts/shipment/test_snapshots/test/test_governance_get_proposal_snapshot_ledger_returns_ledger_at_creation.1.json
@@ -1,0 +1,1076 @@
+{
+  "generators": {
+    "address": 7,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "init_multisig",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "update_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "batch_operation_limit"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "default_shipment_limit"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "governance_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_metadata_entries"
+                      },
+                      "val": {
+                        "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_proposal_tokens"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_status_update_interval"
+                      },
+                      "val": {
+                        "u64": 60
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_max_admins"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_min_admins"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposal_expiry_seconds"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_extension"
+                      },
+                      "val": {
+                        "u32": 518400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_threshold"
+                      },
+                      "val": {
+                        "u32": 17280
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "vote_lock_ledgers"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "propose_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "TransferAdmin"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GovToken"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GOV"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalSupply"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000200
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Proposal"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Proposal"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "action"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "TransferAdmin"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "approvals"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminList"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContractConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "batch_operation_limit"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "default_shipment_limit"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "max_metadata_entries"
+                              },
+                              "val": {
+                                "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_status_update_interval"
+                              },
+                              "val": {
+                                "u64": 60
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_max_admins"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_min_admins"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_expiry_seconds"
+                              },
+                              "val": {
+                                "u64": 604800
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_extension"
+                              },
+                              "val": {
+                                "u32": 518400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_threshold"
+                              },
+                              "val": {
+                                "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ProposalCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentLimit"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/shipment/test_snapshots/test/test_governance_propose_fails_below_min_proposal_tokens.1.json
+++ b/contracts/shipment/test_snapshots/test/test_governance_propose_fails_below_min_proposal_tokens.1.json
@@ -1,0 +1,771 @@
+{
+  "generators": {
+    "address": 7,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "init_multisig",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "update_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "batch_operation_limit"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "default_shipment_limit"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "governance_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_metadata_entries"
+                      },
+                      "val": {
+                        "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_proposal_tokens"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_status_update_interval"
+                      },
+                      "val": {
+                        "u64": 60
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_max_admins"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_min_admins"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposal_expiry_seconds"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_extension"
+                      },
+                      "val": {
+                        "u32": 518400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_threshold"
+                      },
+                      "val": {
+                        "u32": 17280
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "vote_lock_ledgers"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 50
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GovToken"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GOV"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalSupply"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000050
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminList"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContractConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "batch_operation_limit"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "default_shipment_limit"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "max_metadata_entries"
+                              },
+                              "val": {
+                                "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 100
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_status_update_interval"
+                              },
+                              "val": {
+                                "u64": 60
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_max_admins"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_min_admins"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_expiry_seconds"
+                              },
+                              "val": {
+                                "u64": 604800
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_extension"
+                              },
+                              "val": {
+                                "u32": 518400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_threshold"
+                              },
+                              "val": {
+                                "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ProposalCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentLimit"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/shipment/test_snapshots/test/test_governance_propose_succeeds_with_min_proposal_tokens_and_snapshot_ledger.1.json
+++ b/contracts/shipment/test_snapshots/test/test_governance_propose_succeeds_with_min_proposal_tokens_and_snapshot_ledger.1.json
@@ -1,0 +1,1075 @@
+{
+  "generators": {
+    "address": 7,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "init_multisig",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "update_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "batch_operation_limit"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "default_shipment_limit"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "governance_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_metadata_entries"
+                      },
+                      "val": {
+                        "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_proposal_tokens"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_status_update_interval"
+                      },
+                      "val": {
+                        "u64": 60
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_max_admins"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_min_admins"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposal_expiry_seconds"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_extension"
+                      },
+                      "val": {
+                        "u32": 518400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_threshold"
+                      },
+                      "val": {
+                        "u32": 17280
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "vote_lock_ledgers"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "propose_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "TransferAdmin"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 200
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 200
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GovToken"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GOV"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalSupply"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000400
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Proposal"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Proposal"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "action"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "TransferAdmin"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "approvals"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminList"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContractConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "batch_operation_limit"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "default_shipment_limit"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "max_metadata_entries"
+                              },
+                              "val": {
+                                "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 100
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_status_update_interval"
+                              },
+                              "val": {
+                                "u64": 60
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_max_admins"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_min_admins"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_expiry_seconds"
+                              },
+                              "val": {
+                                "u64": 604800
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_extension"
+                              },
+                              "val": {
+                                "u32": 518400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_threshold"
+                              },
+                              "val": {
+                                "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ProposalCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentLimit"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 200
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 200
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/shipment/test_snapshots/test/test_governance_snapshot_voting_power_unchanged_after_transfer.1.json
+++ b/contracts/shipment/test_snapshots/test/test_governance_snapshot_voting_power_unchanged_after_transfer.1.json
@@ -1,0 +1,1254 @@
+{
+  "generators": {
+    "address": 8,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "init_multisig",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "update_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "batch_operation_limit"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "default_shipment_limit"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "governance_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_metadata_entries"
+                      },
+                      "val": {
+                        "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_proposal_tokens"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_status_update_interval"
+                      },
+                      "val": {
+                        "u64": 60
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_max_admins"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_min_admins"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposal_expiry_seconds"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_extension"
+                      },
+                      "val": {
+                        "u32": 518400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_threshold"
+                      },
+                      "val": {
+                        "u32": 17280
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "vote_lock_ledgers"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "propose_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "TransferAdmin"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "approve_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GovToken"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GOV"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalSupply"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000200
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Proposal"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Proposal"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "action"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "TransferAdmin"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "approvals"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminList"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContractConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "batch_operation_limit"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "default_shipment_limit"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "max_metadata_entries"
+                              },
+                              "val": {
+                                "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_status_update_interval"
+                              },
+                              "val": {
+                                "u64": 60
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_max_admins"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_min_admins"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_expiry_seconds"
+                              },
+                              "val": {
+                                "u64": 604800
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_extension"
+                              },
+                              "val": {
+                                "u32": 518400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_threshold"
+                              },
+                              "val": {
+                                "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ProposalCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentLimit"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 8370022561469687789
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 8370022561469687789
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/shipment/test_snapshots/test/test_governance_vote_lock_set_after_approve.1.json
+++ b/contracts/shipment/test_snapshots/test/test_governance_vote_lock_set_after_approve.1.json
@@ -1,0 +1,1192 @@
+{
+  "generators": {
+    "address": 7,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "init_multisig",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "update_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "batch_operation_limit"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "default_shipment_limit"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "governance_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_metadata_entries"
+                      },
+                      "val": {
+                        "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_proposal_tokens"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_status_update_interval"
+                      },
+                      "val": {
+                        "u64": 60
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_max_admins"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "multisig_min_admins"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposal_expiry_seconds"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_extension"
+                      },
+                      "val": {
+                        "u32": 518400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "shipment_ttl_threshold"
+                      },
+                      "val": {
+                        "u32": 17280
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "vote_lock_ledgers"
+                      },
+                      "val": {
+                        "u32": 100
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "propose_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "TransferAdmin"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "approve_action",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GovToken"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "GOV"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalSupply"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000200
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Proposal"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Proposal"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "action"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "TransferAdmin"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "approvals"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 604800
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "proposer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AdminList"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContractConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "batch_operation_limit"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "default_shipment_limit"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "max_metadata_entries"
+                              },
+                              "val": {
+                                "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_status_update_interval"
+                              },
+                              "val": {
+                                "u64": 60
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_max_admins"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "multisig_min_admins"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_expiry_seconds"
+                              },
+                              "val": {
+                                "u64": 604800
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_extension"
+                              },
+                              "val": {
+                                "u32": 518400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "shipment_ttl_threshold"
+                              },
+                              "val": {
+                                "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ProposalCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Role"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Company"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ShipmentLimit"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SnapshotBalance"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "UserRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "Company"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Version"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "VoteLock"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            },
+                            {
+                              "u64": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 100
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/shipment/test_snapshots/test/test_handoff_cancelled_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_cancelled_shipment.1.json
@@ -564,10 +564,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -616,6 +633,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_handoff_delivered_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_delivered_shipment.1.json
@@ -539,10 +539,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -591,6 +608,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_handoff_invalid_new_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_invalid_new_carrier.1.json
@@ -561,10 +561,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -613,6 +630,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_handoff_nonexistent_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_nonexistent_shipment.1.json
@@ -224,10 +224,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -276,6 +293,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_handoff_shipment_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_shipment_returns_shipment_not_found.1.json
@@ -224,10 +224,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -276,6 +293,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_handoff_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_unauthorized.1.json
@@ -616,10 +616,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -668,6 +685,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_handoff_wrong_current_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_handoff_wrong_current_carrier.1.json
@@ -671,10 +671,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -723,6 +740,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_invalid_threshold_too_high.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_invalid_threshold_too_high.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_invalid_threshold_zero.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_invalid_threshold_zero.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_returns_invalid_multisig_config_empty_admins.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_returns_invalid_multisig_config_empty_admins.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_returns_invalid_multisig_config_threshold_too_high.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_returns_invalid_multisig_config_threshold_too_high.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_returns_invalid_multisig_config_threshold_zero.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_returns_invalid_multisig_config_threshold_zero.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_success.1.json
@@ -204,10 +204,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -256,6 +273,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_init_multisig_too_few_admins.1.json
+++ b/contracts/shipment/test_snapshots/test/test_init_multisig_too_few_admins.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_is_carrier_whitelisted_returns_false_for_non_whitelisted.1.json
+++ b/contracts/shipment/test_snapshots/test/test_is_carrier_whitelisted_returns_false_for_non_whitelisted.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_manual_ttl_extension.1.json
+++ b/contracts/shipment/test_snapshots/test/test_manual_ttl_extension.1.json
@@ -430,10 +430,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -482,6 +499,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_milestone_payment_delivery_releases_remaining.1.json
+++ b/contracts/shipment/test_snapshots/test/test_milestone_payment_delivery_releases_remaining.1.json
@@ -734,10 +734,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -786,6 +803,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_milestone_payment_duplicate_record_no_double_pay.1.json
+++ b/contracts/shipment/test_snapshots/test/test_milestone_payment_duplicate_record_no_double_pay.1.json
@@ -692,10 +692,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -744,6 +761,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_milestone_payment_invalid_sum_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_milestone_payment_invalid_sum_fails.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_milestone_payment_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_milestone_payment_success.1.json
@@ -747,10 +747,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -799,6 +816,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_multiple_carriers_whitelist.1.json
+++ b/contracts/shipment/test_snapshots/test/test_multiple_carriers_whitelist.1.json
@@ -257,10 +257,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -309,6 +326,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_multiple_shipments_have_unique_ids.1.json
+++ b/contracts/shipment/test_snapshots/test/test_multiple_shipments_have_unique_ids.1.json
@@ -919,10 +919,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -971,6 +988,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_notification_emitted_on_delivery_confirmed.1.json
+++ b/contracts/shipment/test_snapshots/test/test_notification_emitted_on_delivery_confirmed.1.json
@@ -630,10 +630,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -682,6 +699,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_notification_emitted_on_dispute_raised.1.json
+++ b/contracts/shipment/test_snapshots/test/test_notification_emitted_on_dispute_raised.1.json
@@ -453,10 +453,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -505,6 +522,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_notification_emitted_on_dispute_resolved.1.json
+++ b/contracts/shipment/test_snapshots/test/test_notification_emitted_on_dispute_resolved.1.json
@@ -543,10 +543,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -595,6 +612,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_notification_emitted_on_shipment_created.1.json
+++ b/contracts/shipment/test_snapshots/test/test_notification_emitted_on_shipment_created.1.json
@@ -428,10 +428,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -480,6 +497,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_notification_emitted_on_status_changed.1.json
+++ b/contracts/shipment/test_snapshots/test/test_notification_emitted_on_status_changed.1.json
@@ -505,10 +505,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -557,6 +574,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_only_admin_can_assign_roles.1.json
+++ b/contracts/shipment/test_snapshots/test/test_only_admin_can_assign_roles.1.json
@@ -225,10 +225,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -277,6 +294,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_only_carrier_can_update_status_and_record_milestones.1.json
+++ b/contracts/shipment/test_snapshots/test/test_only_carrier_can_update_status_and_record_milestones.1.json
@@ -710,10 +710,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -762,6 +779,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_only_company_can_create_shipments.1.json
+++ b/contracts/shipment/test_snapshots/test/test_only_company_can_create_shipments.1.json
@@ -485,10 +485,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -537,6 +554,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_only_receiver_can_confirm_delivery.1.json
+++ b/contracts/shipment/test_snapshots/test/test_only_receiver_can_confirm_delivery.1.json
@@ -955,10 +955,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -1007,6 +1024,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_proposal_expiration.1.json
+++ b/contracts/shipment/test_snapshots/test/test_proposal_expiration.1.json
@@ -248,6 +248,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -340,10 +348,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -392,6 +417,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_propose_action_not_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_propose_action_not_admin.1.json
@@ -198,10 +198,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -250,6 +267,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_propose_action_returns_not_an_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_propose_action_returns_not_an_admin.1.json
@@ -513,10 +513,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -565,6 +582,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_propose_action_upgrade.1.json
+++ b/contracts/shipment/test_snapshots/test/test_propose_action_upgrade.1.json
@@ -251,6 +251,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -346,10 +354,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -398,6 +423,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_raise_dispute_by_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_raise_dispute_by_carrier.1.json
@@ -454,10 +454,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -506,6 +523,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_raise_dispute_by_receiver.1.json
+++ b/contracts/shipment/test_snapshots/test/test_raise_dispute_by_receiver.1.json
@@ -454,10 +454,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -506,6 +523,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_raise_dispute_by_sender.1.json
+++ b/contracts/shipment/test_snapshots/test/test_raise_dispute_by_sender.1.json
@@ -483,10 +483,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -535,6 +552,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_raise_dispute_on_cancelled_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_raise_dispute_on_cancelled_shipment.1.json
@@ -430,10 +430,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -482,6 +499,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_raise_dispute_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_raise_dispute_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_raise_dispute_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_raise_dispute_unauthorized.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_rate_limit_admin_bypasses.1.json
+++ b/contracts/shipment/test_snapshots/test/test_rate_limit_admin_bypasses.1.json
@@ -724,10 +724,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -776,6 +793,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_rate_limit_rapid_update_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_rate_limit_rapid_update_fails.1.json
@@ -561,10 +561,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -613,6 +630,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_rate_limit_update_after_interval_succeeds.1.json
+++ b/contracts/shipment/test_snapshots/test/test_rate_limit_update_after_interval_succeeds.1.json
@@ -593,10 +593,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -645,6 +662,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_rbac_all_gated_functions_with_wrong_role.1.json
+++ b/contracts/shipment/test_snapshots/test/test_rbac_all_gated_functions_with_wrong_role.1.json
@@ -493,10 +493,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -545,6 +562,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_re_initialization_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_re_initialization_fails.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_re_initialization_with_different_admin_fails.1.json
+++ b/contracts/shipment/test_snapshots/test/test_re_initialization_with_different_admin_fails.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestone_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestone_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestone_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestone_success.1.json
@@ -512,10 +512,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -564,6 +581,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestone_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestone_unauthorized.1.json
@@ -485,10 +485,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -537,6 +554,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestone_wrong_status.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestone_wrong_status.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_invalid_status.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_invalid_status.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_max_size.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_max_size.1.json
@@ -610,10 +610,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -662,6 +679,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_oversized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_oversized.1.json
@@ -485,10 +485,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -537,6 +554,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_single_milestone.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_single_milestone.1.json
@@ -520,10 +520,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -572,6 +589,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_success.1.json
@@ -540,10 +540,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -592,6 +609,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_unauthorized.1.json
@@ -485,10 +485,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -537,6 +554,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_record_milestones_batch_with_payment_milestones.1.json
+++ b/contracts/shipment/test_snapshots/test/test_record_milestones_batch_with_payment_milestones.1.json
@@ -628,10 +628,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -680,6 +697,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_refund_escrow_by_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_refund_escrow_by_admin.1.json
@@ -512,10 +512,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -564,6 +581,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_refund_escrow_double_refund.1.json
+++ b/contracts/shipment/test_snapshots/test/test_refund_escrow_double_refund.1.json
@@ -479,10 +479,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -531,6 +548,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_refund_escrow_on_delivered_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_refund_escrow_on_delivered_shipment.1.json
@@ -458,10 +458,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -510,6 +527,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_refund_escrow_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_refund_escrow_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_refund_escrow_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_refund_escrow_success.1.json
@@ -479,10 +479,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -531,6 +548,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_refund_escrow_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_refund_escrow_unauthorized.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_release_escrow_by_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_release_escrow_by_admin.1.json
@@ -513,10 +513,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -565,6 +582,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_release_escrow_double_release.1.json
+++ b/contracts/shipment/test_snapshots/test/test_release_escrow_double_release.1.json
@@ -480,10 +480,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -532,6 +549,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_release_escrow_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_release_escrow_returns_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_release_escrow_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_release_escrow_success.1.json
@@ -480,10 +480,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -532,6 +549,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_release_escrow_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_release_escrow_unauthorized.1.json
@@ -458,10 +458,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -510,6 +527,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_release_escrow_wrong_status.1.json
+++ b/contracts/shipment/test_snapshots/test/test_release_escrow_wrong_status.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_remove_carrier_from_whitelist.1.json
+++ b/contracts/shipment/test_snapshots/test/test_remove_carrier_from_whitelist.1.json
@@ -214,10 +214,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -266,6 +283,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_remove_carrier_from_whitelist_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_remove_carrier_from_whitelist_returns_unauthorized.1.json
@@ -209,10 +209,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -261,6 +278,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_condition_breach_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_condition_breach_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_condition_breach_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_condition_breach_returns_unauthorized.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_condition_breach_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_condition_breach_success.1.json
@@ -516,10 +516,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -568,6 +585,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_condition_breach_unauthorized_non_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_condition_breach_unauthorized_non_carrier.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_condition_breach_wrong_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_condition_breach_wrong_carrier.1.json
@@ -539,10 +539,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -591,6 +608,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_geofence_event_non_existent_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_geofence_event_non_existent_shipment.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_geofence_event_unauthorized_role.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_geofence_event_unauthorized_role.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_geofence_route_deviation.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_geofence_route_deviation.1.json
@@ -515,10 +515,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -567,6 +584,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_geofence_zone_entry.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_geofence_zone_entry.1.json
@@ -515,10 +515,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -567,6 +584,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_report_geofence_zone_exit.1.json
+++ b/contracts/shipment/test_snapshots/test/test_report_geofence_zone_exit.1.json
@@ -515,10 +515,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -567,6 +584,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_resolve_dispute_not_disputed.1.json
+++ b/contracts/shipment/test_snapshots/test/test_resolve_dispute_not_disputed.1.json
@@ -457,10 +457,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -509,6 +526,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_resolve_dispute_refund_to_company.1.json
+++ b/contracts/shipment/test_snapshots/test/test_resolve_dispute_refund_to_company.1.json
@@ -544,10 +544,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -596,6 +613,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_resolve_dispute_release_to_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_resolve_dispute_release_to_carrier.1.json
@@ -544,10 +544,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -596,6 +613,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_resolve_dispute_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_resolve_dispute_returns_shipment_not_found.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_resolve_dispute_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_resolve_dispute_unauthorized.1.json
@@ -482,10 +482,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -534,6 +551,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_set_and_get_shipment_limit.1.json
+++ b/contracts/shipment/test_snapshots/test/test_set_and_get_shipment_limit.1.json
@@ -170,10 +170,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -222,6 +239,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_set_shipment_limit_returns_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_set_shipment_limit_returns_unauthorized.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_set_shipment_limit_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_set_shipment_limit_unauthorized.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_shipment_counter_starts_at_zero.1.json
+++ b/contracts/shipment/test_snapshots/test/test_shipment_counter_starts_at_zero.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_shipment_limit_reached.1.json
+++ b/contracts/shipment/test_snapshots/test/test_shipment_limit_reached.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_successful_admin_transfer.1.json
+++ b/contracts/shipment/test_snapshots/test/test_successful_admin_transfer.1.json
@@ -189,10 +189,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -241,6 +258,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_successful_handoff.1.json
+++ b/contracts/shipment/test_snapshots/test/test_successful_handoff.1.json
@@ -644,10 +644,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -696,6 +713,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_successful_initialization.1.json
+++ b/contracts/shipment/test_snapshots/test/test_successful_initialization.1.json
@@ -116,10 +116,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -168,6 +185,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_three_of_five_multisig.1.json
+++ b/contracts/shipment/test_snapshots/test/test_three_of_five_multisig.1.json
@@ -309,6 +309,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -410,10 +418,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -462,6 +487,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_transfer_admin_action.1.json
+++ b/contracts/shipment/test_snapshots/test/test_transfer_admin_action.1.json
@@ -273,6 +273,14 @@
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "snapshot_ledger"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -365,10 +373,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -417,6 +442,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_ttl_extension_on_shipment_creation.1.json
+++ b/contracts/shipment/test_snapshots/test/test_ttl_extension_on_shipment_creation.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_unassigned_addresses_are_rejected.1.json
+++ b/contracts/shipment/test_snapshots/test/test_unassigned_addresses_are_rejected.1.json
@@ -116,10 +116,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -168,6 +185,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_unauthorized_admin_acceptance.1.json
+++ b/contracts/shipment/test_snapshots/test/test_unauthorized_admin_acceptance.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_unauthorized_admin_transfer.1.json
+++ b/contracts/shipment/test_snapshots/test/test_unauthorized_admin_transfer.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_eta_rejects_past_timestamp.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_eta_rejects_past_timestamp.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_eta_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_eta_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_eta_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_eta_unauthorized.1.json
@@ -484,10 +484,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -536,6 +553,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_eta_valid_emits_event.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_eta_valid_emits_event.1.json
@@ -511,10 +511,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -563,6 +580,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_invalid_transition.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_invalid_transition.1.json
@@ -538,10 +538,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -590,6 +607,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_multiple_valid_transitions.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_multiple_valid_transitions.1.json
@@ -573,10 +573,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -625,6 +642,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_nonexistent_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_nonexistent_shipment.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_returns_rate_limit_exceeded.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_returns_rate_limit_exceeded.1.json
@@ -506,10 +506,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -558,6 +575,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_returns_shipment_not_found.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_returns_shipment_not_found.1.json
@@ -169,10 +169,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -221,6 +238,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_unauthorized.1.json
@@ -429,10 +429,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -481,6 +498,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_valid_transition_by_admin.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_valid_transition_by_admin.1.json
@@ -539,10 +539,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -591,6 +608,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_update_status_valid_transition_by_carrier.1.json
+++ b/contracts/shipment/test_snapshots/test/test_update_status_valid_transition_by_carrier.1.json
@@ -507,10 +507,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -559,6 +576,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_upgrade_success.1.json
+++ b/contracts/shipment/test_snapshots/test/test_upgrade_success.1.json
@@ -170,10 +170,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -222,6 +239,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_upgrade_unauthorized.1.json
+++ b/contracts/shipment/test_snapshots/test/test_upgrade_unauthorized.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_verify_delivery_proof_match.1.json
+++ b/contracts/shipment/test_snapshots/test/test_verify_delivery_proof_match.1.json
@@ -631,10 +631,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -683,6 +700,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_verify_delivery_proof_mismatch.1.json
+++ b/contracts/shipment/test_snapshots/test/test_verify_delivery_proof_mismatch.1.json
@@ -631,10 +631,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -683,6 +700,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_verify_delivery_proof_nonexistent_shipment.1.json
+++ b/contracts/shipment/test_snapshots/test/test_verify_delivery_proof_nonexistent_shipment.1.json
@@ -114,10 +114,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -166,6 +183,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/contracts/shipment/test_snapshots/test/test_whitelist_per_company.1.json
+++ b/contracts/shipment/test_snapshots/test/test_whitelist_per_company.1.json
@@ -307,10 +307,27 @@
                             },
                             {
                               "key": {
+                                "symbol": "governance_token"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
                                 "symbol": "max_metadata_entries"
                               },
                               "val": {
                                 "u32": 5
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "min_proposal_tokens"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
                               }
                             },
                             {
@@ -359,6 +376,14 @@
                               },
                               "val": {
                                 "u32": 17280
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "vote_lock_ledgers"
+                              },
+                              "val": {
+                                "u32": 0
                               }
                             }
                           ]

--- a/docs/plans/2026-02-26-governance-token-and-snapshot-voting.md
+++ b/docs/plans/2026-02-26-governance-token-and-snapshot-voting.md
@@ -1,0 +1,74 @@
+# Governance Token and Snapshot Voting Implementation Plan
+
+> **For Claude:** Implement governance token integration (#213) and proposal snapshot voting (#212) in the shipment contract.
+
+**Goal:** Add token-weighted voting for proposals with snapshot at creation time, delegation, minimum token threshold, and vote locking. PR must close #212 and #213 with no agent trailers or watermarks.
+
+**Architecture:** Extend `ContractConfig` with governance token settings; add `Proposal.snapshot_ledger` and snapshot-based power; add storage for token balance snapshots, delegations, and vote locks; keep existing multi-sig proposal flow but gate creation/voting by token power and use snapshot for approval checks.
+
+**Tech Stack:** Rust, Soroban SDK, existing shipment contract (lib.rs, types.rs, config.rs, storage.rs, test.rs).
+
+**File paths (this repo):** `contracts/shipment/src/{lib.rs, types.rs, config.rs, storage.rs, test.rs}`.
+
+---
+
+## Task 1: Types and config (governance token + snapshot)
+
+**Files:** `contracts/shipment/src/types.rs`, `contracts/shipment/src/config.rs`
+
+- Add to `ContractConfig`: `governance_token: Option<Address>`, `min_proposal_tokens: i128`, `vote_lock_ledgers: u32`.
+- Add to `Proposal`: `snapshot_ledger: u32` (voting power determined at this ledger).
+- Add `DataKey` variants: `VoteLock(Address, u64)`, `Delegation(Address)`, `SnapshotBalance(u64, Address)` (proposal_id, address -> balance at snapshot).
+- Add types: `VotePower` or use `i128` for snapshot balance; ensure `Proposal` is backward-compatible (default snapshot_ledger to 0 if needed for existing tests).
+
+---
+
+## Task 2: Storage helpers
+
+**Files:** `contracts/shipment/src/storage.rs`
+
+- Implement get/set for snapshot balance per (proposal_id, address).
+- Implement get/set for delegation (delegatee -> delegator).
+- Implement get/set for vote lock (address, proposal_id) -> lock until ledger.
+- Add helpers: `get_voting_power_at_ledger(env, proposal_id, address)` using snapshot first, then fallback to current token balance if no snapshot (for backward compat during rollout).
+
+---
+
+## Task 3: Lib – token config, snapshot at creation, vote logic
+
+**Files:** `contracts/shipment/src/lib.rs`
+
+- In `initialize` / config update: persist governance token and min_proposal_tokens, vote_lock_ledgers.
+- In `propose_action`: require proposer’s token balance (or delegated balance) >= min_proposal_tokens; capture current ledger as `proposal.snapshot_ledger`; snapshot voting power for proposer (and optionally all admins) into `SnapshotBalance(proposal_id, address)`.
+- When counting approvals: use snapshot-based voting power (sum of snapshot balances of approvers) and require total snapshot power >= threshold (e.g. threshold can be a fixed quorum or existing multisig count). Alternatively: keep “N of M admins” but require each approver to have had at least X tokens at snapshot; document choice.
+- Add token lock on vote: when an admin approves, lock their tokens until `current_ledger + vote_lock_ledgers` (store in `VoteLock(address, proposal_id)` or by proposal expiry).
+- Delegation: add `set_delegation(env, delegator, delegatee)` so delegatee’s voting power = delegator’s balance; store in `Delegation(delegatee)` -> delegator; when reading balance for snapshot/voting, use delegated balance if configured.
+- Add `get_proposal_snapshot_ledger(env, proposal_id)` and snapshot verification / historical query helpers as needed.
+
+---
+
+## Task 4: Tests
+
+**Files:** `contracts/shipment/src/test.rs`
+
+- Governance token: config set with token address and min_proposal_tokens; proposal creation fails if below threshold; proposal creation succeeds when above; token-weighted approval check (or min-token check per approver).
+- Snapshot: create proposal, capture snapshot_ledger; transfer tokens away from approver; approval still uses snapshot power so vote counts.
+- Vote lock: after approve, tokens are locked until lock expiry; withdraw/transfer restricted or lock enforced in contract.
+- Delegation: set delegation, create proposal; delegatee’s voting power equals delegator’s balance at snapshot.
+- Snapshot verification and historical query tests.
+- All existing proposal tests still pass (backward compat).
+
+---
+
+## Acceptance (from issues)
+
+- #213: Token configuration, balance checking, weighted calculation, token delegation, minimum threshold, vote locking, tests pass.
+- #212: snapshot_ledger field, power snapshot at creation, snapshot-based checking, storage optimization, verification, historical queries, tests pass.
+
+---
+
+## PR / Commit
+
+- One branch: `feature/governance-token-and-snapshot-voting`.
+- Single clean commit (or minimal commits) with message that references closing issues, e.g. “Implement governance token integration and snapshot voting. Fixes #212. Fixes #213.” — no Cursor/agent trailers or watermarks.
+- Push to fork and open PR; ensure PR description closes #212 and #213 (Fixes #212, Fixes #213).


### PR DESCRIPTION
## Description

Adds governance token integration (#213) and proposal snapshot voting (#212) to the shipment contract.

- **Governance token:** Config fields `governance_token`, `min_proposal_tokens`, `vote_lock_ledgers`. Token holders can propose and vote with power proportional to holdings. Delegation supported.
- **Snapshot voting:** `Proposal.snapshot_ledger` and snapshot balances at creation; approval power uses snapshot so transfers cannot manipulate votes. Vote lock during voting.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

## How Has This Been Tested?

- [x] Unit tests added/updated (governance and snapshot tests)
- [x] All tests pass locally (cargo test -p shipment)

## Checklist

- [x] cargo fmt --check passes
- [x] cargo clippy and cargo test pass
- [x] No agent/Cursor trailers or watermarks in commits or PR

