### PR TITLE
feat: implement role revocation

### DIFF
--- a/contracts/shipment/src/errors.rs
+++ b/contracts/shipment/src/errors.rs
@@ -76,4 +76,6 @@ pub enum NavinError {
     ShipmentLimitReached = 30,
     /// Invalid configuration parameters provided.
     InvalidConfig = 31,
+    /// Admin cannot revoke their own role; use `transfer_admin` instead.
+    CannotSelfRevoke = 32,
 }

--- a/contracts/shipment/src/events.rs
+++ b/contracts/shipment/src/events.rs
@@ -704,6 +704,36 @@ pub fn emit_carrier_handoff_completed(
     );
 }
 
+/// Emits a `role_revoked` event when an admin revokes a role from an address.
+///
+/// # Event Data
+///
+/// | Field   | Type      | Description                                |
+/// |---------|-----------|--------------------------------------------|
+/// | admin   | `Address` | Admin that performed the revocation         |
+/// | target  | `Address` | Address whose role was revoked              |
+/// | role    | `Role`    | The role that was revoked                   |
+///
+/// # Arguments
+/// * `env` - The execution environment.
+/// * `admin` - The admin who revoked the role.
+/// * `target` - The address whose role was revoked.
+/// * `role` - The role that was revoked.
+///
+/// # Returns
+/// No value returned.
+///
+/// # Examples
+/// ```rust
+/// // events::emit_role_revoked(&env, &admin, &target, &Role::Company);
+/// ```
+pub fn emit_role_revoked(env: &Env, admin: &Address, target: &Address, role: &crate::types::Role) {
+    env.events().publish(
+        (Symbol::new(env, "role_revoked"),),
+        (admin.clone(), target.clone(), role.clone()),
+    );
+}
+
 /// Emits a `carrier_milestone_rate` event to track completeness of checkpoint reporting.
 pub fn emit_carrier_milestone_rate(
     env: &Env,

--- a/contracts/shipment/src/storage.rs
+++ b/contracts/shipment/src/storage.rs
@@ -283,6 +283,29 @@ pub fn set_carrier_role(env: &Env, carrier: &Address) {
     set_role(env, carrier, &Role::Carrier);
 }
 
+/// Revoke a role from an address in instance storage.
+///
+/// Removes the `UserRole(address, role)` key and resets the legacy
+/// `Role(address)` key to `Unassigned`.
+///
+/// # Arguments
+/// * `env` - The execution environment.
+/// * `address` - The address whose role is being revoked.
+/// * `role` - The role to revoke.
+///
+/// # Examples
+/// ```rust
+/// // storage::revoke_role(&env, &user_addr, &Role::Company);
+/// ```
+pub fn revoke_role(env: &Env, address: &Address, role: &Role) {
+    let key = DataKey::UserRole(address.clone(), role.clone());
+    env.storage().instance().remove(&key);
+    // Reset legacy single-role slot to Unassigned
+    env.storage()
+        .instance()
+        .set(&DataKey::Role(address.clone()), &Role::Unassigned);
+}
+
 /// Check whether an address has Company role (legacy compatibility)
 #[allow(dead_code)]
 pub fn has_company_role(env: &Env, address: &Address) -> bool {


### PR DESCRIPTION
## Summary
- Implements `revoke_role(env, admin, target)` allowing admin to remove a previously assigned role from any address
- Admin cannot self-revoke (returns `CannotSelfRevoke` error — must use `transfer_admin` instead)
- Emits a `role_revoked` event on successful revocation
- Revoked users immediately lose access to all role-gated functions

## Changes
- **errors.rs**: New `CannotSelfRevoke = 32` error variant
- **storage.rs**: New `revoke_role()` helper — clears `UserRole` key and resets legacy `Role` key to `Unassigned`
- **events.rs**: New `emit_role_revoked()` event emitter
- **lib.rs**: New `revoke_role()` contract method with admin auth, self-revoke guard, and event emission
- **test.rs**: 6 unit tests covering all acceptance criteria

## Checklist
- [x] `revoke_role` implemented
- [x] At least 3 unit tests (6 total: company revoke, carrier revoke, revoke-then-operate-fails, self-revoke-fails, unauthorized, event emission)
- [x] `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — all 278 tests pass
- [x] `cargo build --target wasm32-unknown-unknown --release` — WASM builds

## Test plan
- [x] Revoke Company role → `get_role` returns `Unassigned`
- [x] Revoke Carrier role → `get_role` returns `Unassigned`
- [x] Revoked company cannot create shipments (fails with `Unauthorized`)
- [x] Admin self-revoke fails with `CannotSelfRevoke` (error code 32)
- [x] Non-admin cannot revoke roles (fails with `Unauthorized`)
- [x] `role_revoked` event is emitted

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)