### PR TITLE
fix: update tests to expect ShipmentFinalized (#38) after finalization guard

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -18,6 +18,8 @@ mod types;
 mod validation;
 
 #[cfg(test)]
+mod test_auth;
+#[cfg(test)]
 mod test_suspension;
 #[cfg(test)]
 mod test_utils;

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use soroban_sdk::{
     contract, contractimpl,
-    testutils::{storage::Persistent, Address as _, Events, Ledger as _},
+    testutils::{storage::Persistent, Address as _, Events},
     Address, BytesN, Env, Symbol, TryFromVal,
 };
 
@@ -486,7 +486,7 @@ fn test_update_status_valid_transition_by_admin() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #5)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_update_status_invalid_transition() {
     use crate::ShipmentStatus;
     let (env, client, admin, token_contract) = setup_shipment_env();
@@ -516,7 +516,7 @@ fn test_update_status_invalid_transition() {
         &new_data_hash,
     );
 
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(
         &carrier,
         &shipment_id,
@@ -524,7 +524,7 @@ fn test_update_status_invalid_transition() {
         &new_data_hash,
     );
 
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     // Invalid: Delivered → Created
     client.update_status(
         &carrier,
@@ -605,7 +605,7 @@ fn test_update_status_multiple_valid_transitions() {
     );
 
     // InTransit → AtCheckpoint
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(
         &carrier,
         &shipment_id,
@@ -618,7 +618,7 @@ fn test_update_status_multiple_valid_transitions() {
     );
 
     // AtCheckpoint → Delivered
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::Delivered, &hash_4);
     assert_eq!(
         client.get_shipment(&shipment_id).status,
@@ -686,7 +686,7 @@ fn test_suspend_and_reactivate_carrier_for_status_updates() {
     client.reactivate_carrier(&admin, &carrier);
     assert!(!client.is_carrier_suspended(&carrier));
 
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(
         &carrier,
         &shipment_id,
@@ -1477,7 +1477,7 @@ fn test_release_escrow_success() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_release_escrow_double_release() {
     let (env, client, admin, token_contract) = setup_shipment_env();
     let company = Address::generate(&env);
@@ -1738,7 +1738,7 @@ fn test_refund_escrow_by_admin() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_refund_escrow_double_refund() {
     let (env, client, admin, token_contract) = setup_shipment_env();
     let company = Address::generate(&env);
@@ -2786,7 +2786,7 @@ fn test_escrow_happy_path_create_deposit_transit_deliver_confirm() {
     client.deposit_escrow(&company, &shipment_id, &escrow_amount);
 
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::InTransit, &hash2);
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(
         &carrier,
         &shipment_id,
@@ -2858,7 +2858,7 @@ fn test_escrow_dispute_resolve_to_delivered() {
     );
     client.deposit_escrow(&company, &shipment_id, &escrow_amount);
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::InTransit, &hash2);
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::Disputed, &hash3);
     client.update_status(&admin, &shipment_id, &ShipmentStatus::Delivered, &hash3);
 
@@ -2893,7 +2893,7 @@ fn test_escrow_dispute_resolve_to_cancelled() {
     );
     client.deposit_escrow(&company, &shipment_id, &escrow_amount);
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::InTransit, &hash2);
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::Disputed, &hash2);
     client.update_status(
         &admin,
@@ -2961,7 +2961,7 @@ fn test_escrow_release_without_delivery_confirm_from_created_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_escrow_refund_after_delivery_fails() {
     let (env, client, admin, token_contract) = setup_shipment_env();
     let company = Address::generate(&env);
@@ -3582,7 +3582,7 @@ fn test_handoff_delivered_shipment() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_handoff_cancelled_shipment() {
     let (env, client, admin, token_contract) = setup_shipment_env();
     let company = Address::generate(&env);
@@ -3955,9 +3955,7 @@ fn test_rate_limit_update_after_interval_succeeds() {
     client.update_status(&carrier, &shipment_id, &ShipmentStatus::InTransit, &hash1);
 
     // Advance the ledger timestamp past the 60-second minimum interval
-    env.ledger().with_mut(|l| {
-        l.timestamp += 61;
-    });
+    super::test_utils::advance_past_rate_limit(&env);
 
     // Second update after the interval — should succeed
     client.update_status(
@@ -4648,7 +4646,7 @@ fn test_proposal_expiration() {
     let proposal_id = client.propose_action(&admin1, &action);
 
     // Fast forward time beyond expiration (7 days + 1 second)
-    env.ledger().with_mut(|l| l.timestamp += 604_801);
+    super::test_utils::advance_past_multisig_expiry(&env);
 
     // Try to approve expired proposal - should fail
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -4891,7 +4889,7 @@ fn test_check_deadline_success_auto_cancels_and_refunds() {
     client.deposit_escrow(&company, &shipment_id, &escrow_amount);
 
     // Advance ledger time past the deadline threshold
-    env.ledger().with_mut(|l| l.timestamp += 1001);
+    super::test_utils::advance_ledger_time(&env, 1001);
 
     // Execute the deadline checker
     client.check_deadline(&shipment_id);
@@ -4968,7 +4966,7 @@ fn test_delivery_before_deadline() {
     assert_eq!(shipment.status, ShipmentStatus::Delivered);
 
     // Fast-forward past the deadline point
-    env.ledger().with_mut(|l| l.timestamp += 1001);
+    super::test_utils::advance_ledger_time(&env, 1001);
 
     // Attempting to crank check_deadline on a safely completed shipment errors appropriately (Error 9)
     let res = client.try_check_deadline(&shipment_id);
@@ -6175,7 +6173,7 @@ fn test_count_decrements_on_deadline_expiration() {
     assert_eq!(client.get_active_shipment_count(&company), 1);
 
     // Fast forward time
-    env.ledger().with_mut(|l| l.timestamp = deadline + 1);
+    super::test_utils::set_ledger_time(&env, deadline + 1);
 
     client.check_deadline(&1);
 
@@ -6663,8 +6661,7 @@ fn test_approve_action_returns_proposal_expired() {
     let proposal_id = client.propose_action(&admin, &crate::AdminAction::ForceRelease(shipment_id));
 
     // Fast forward time past expiration (7 days)
-    env.ledger()
-        .with_mut(|l| l.timestamp += 7 * 24 * 60 * 60 + 1);
+    super::test_utils::advance_past_multisig_expiry(&env);
 
     client.approve_action(&admin2, &proposal_id);
 }
@@ -6702,8 +6699,7 @@ fn test_execute_proposal_returns_proposal_expired() {
     client.approve_action(&admin2, &proposal_id);
 
     // Fast forward time past expiration
-    env.ledger()
-        .with_mut(|l| l.timestamp += 7 * 24 * 60 * 60 + 1);
+    super::test_utils::advance_past_multisig_expiry(&env);
 
     client.execute_proposal(&proposal_id);
 }
@@ -7537,7 +7533,7 @@ fn test_full_shipment_lifecycle_integration() {
 
     // ─── STEP 5: Record First Milestone (Warehouse) ──────────────────────────
     // Advance time to bypass rate limiting
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
 
     let warehouse_checkpoint = soroban_sdk::Symbol::new(&env, "warehouse");
     let milestone_hash_1 = BytesN::from_array(&env, &[3u8; 32]);
@@ -7554,7 +7550,7 @@ fn test_full_shipment_lifecycle_integration() {
     assert_eq!(shipment.paid_milestones.len(), 1);
 
     // ─── STEP 6: Update Status to AtCheckpoint ───────────────────────────────
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     let checkpoint_hash = BytesN::from_array(&env, &[4u8; 32]);
     client.update_status(
         &carrier,
@@ -7568,7 +7564,7 @@ fn test_full_shipment_lifecycle_integration() {
     assert_eq!(shipment.status, ShipmentStatus::AtCheckpoint);
 
     // ─── STEP 7: Update Status Back to InTransit ─────────────────────────────
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     let transit_hash_2 = BytesN::from_array(&env, &[5u8; 32]);
     client.update_status(
         &carrier,
@@ -7582,7 +7578,7 @@ fn test_full_shipment_lifecycle_integration() {
     assert_eq!(shipment.status, ShipmentStatus::InTransit);
 
     // ─── STEP 8: Record Second Milestone (Port) ──────────────────────────────
-    env.ledger().with_mut(|l| l.timestamp += 61);
+    super::test_utils::advance_past_rate_limit(&env);
     let port_checkpoint = soroban_sdk::Symbol::new(&env, "port");
     let milestone_hash_2 = BytesN::from_array(&env, &[6u8; 32]);
     client.record_milestone(&carrier, &shipment_id, &port_checkpoint, &milestone_hash_2);
@@ -7785,9 +7781,7 @@ fn test_event_count_after_status_updates() {
     );
 
     // Advance ledger timestamp to avoid rate limit
-    env.ledger().with_mut(|li| {
-        li.timestamp += 61; // Advance by 61 seconds (default min interval is 60)
-    });
+    super::test_utils::advance_past_rate_limit(&env);
 
     // Update status to AtCheckpoint
     let status_hash2 = BytesN::from_array(&env, &[3u8; 32]);
@@ -8315,7 +8309,7 @@ fn test_carrier_late_delivery_event_and_milestones() {
     );
 
     // Advance time past the deadline to trigger a late delivery
-    env.ledger().with_mut(|l| l.timestamp = deadline + 100);
+    super::test_utils::set_ledger_time(&env, deadline + 100);
 
     // Delivery
     let actual_time = env.ledger().timestamp();
@@ -8736,8 +8730,7 @@ fn test_check_deadline_within_grace_period_returns_not_expired() {
 
     // Advance time: deadline has passed, but we are still inside the grace window
     // timestamp = deadline + grace - 1  =>  NOT yet expired
-    env.ledger()
-        .with_mut(|l| l.timestamp = deadline + grace - 1);
+    super::test_utils::set_ledger_time(&env, deadline + grace - 1);
 
     client.check_deadline(&shipment_id);
 }
@@ -8759,7 +8752,7 @@ fn test_check_deadline_at_grace_boundary_succeeds() {
     client.update_config(&admin, &config);
 
     // Advance time to exactly deadline + grace
-    env.ledger().with_mut(|l| l.timestamp = deadline + grace);
+    super::test_utils::set_ledger_time(&env, deadline + grace);
 
     client.check_deadline(&shipment_id);
 
@@ -8784,8 +8777,7 @@ fn test_check_deadline_after_grace_period_cancels_shipment() {
     client.update_config(&admin, &config);
 
     // Advance time well past deadline + grace
-    env.ledger()
-        .with_mut(|l| l.timestamp = deadline + grace + 500);
+    super::test_utils::set_ledger_time(&env, deadline + grace + 500);
 
     client.check_deadline(&shipment_id);
 
@@ -8806,7 +8798,7 @@ fn test_check_deadline_zero_grace_expires_immediately() {
         setup_shipment_with_deadline(&env, &client, &admin, &token_contract, deadline);
 
     // Default config has deadline_grace_seconds = 0
-    env.ledger().with_mut(|l| l.timestamp = deadline + 1);
+    super::test_utils::set_ledger_time(&env, deadline + 1);
 
     client.check_deadline(&shipment_id);
 
@@ -8884,7 +8876,7 @@ fn test_force_cancel_shipment_success_in_transit() {
     let data_hash = BytesN::from_array(&env, &[0x02u8; 32]);
 
     // Move to InTransit via admin (bypasses carrier whitelist requirement)
-    env.ledger().with_mut(|l| l.timestamp += 120);
+    super::test_utils::advance_ledger_time(&env, 120);
     client.update_status(&admin, &shipment_id, &ShipmentStatus::InTransit, &data_hash);
 
     let reason_hash = BytesN::from_array(&env, &[0x03u8; 32]);
@@ -8942,9 +8934,9 @@ fn test_force_cancel_shipment_not_found() {
     client.force_cancel_shipment(&admin, &9999, &reason_hash);
 }
 
-/// Force-cancelling an already-Delivered shipment returns ShipmentAlreadyCompleted (#9).
+/// Force-cancelling an already-Delivered shipment returns ShipmentFinalized (#38).
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_force_cancel_shipment_already_delivered() {
     let (env, client, admin, _token_contract, _company, shipment_id) = setup_force_cancel_env();
 
@@ -8953,23 +8945,23 @@ fn test_force_cancel_shipment_already_delivered() {
     let confirmation_hash = BytesN::from_array(&env, &[0x08u8; 32]);
 
     // Move to InTransit then Delivered via admin
-    env.ledger().with_mut(|l| l.timestamp += 120);
+    super::test_utils::advance_ledger_time(&env, 120);
     client.update_status(
         &admin,
         &shipment_id,
         &ShipmentStatus::InTransit,
         &BytesN::from_array(&env, &[0x09u8; 32]),
     );
-    env.ledger().with_mut(|l| l.timestamp += 120);
+    super::test_utils::advance_ledger_time(&env, 120);
     client.confirm_delivery(&receiver, &shipment_id, &confirmation_hash);
 
     let reason_hash = BytesN::from_array(&env, &[0x0Au8; 32]);
     client.force_cancel_shipment(&admin, &shipment_id, &reason_hash);
 }
 
-/// Force-cancelling an already-Cancelled shipment returns ShipmentAlreadyCompleted (#9).
+/// Force-cancelling an already-Cancelled shipment returns ShipmentFinalized (#38).
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_force_cancel_shipment_already_cancelled() {
     let (env, client, admin, _token_contract, company, shipment_id) = setup_force_cancel_env();
 

--- a/contracts/shipment/src/test_auth.rs
+++ b/contracts/shipment/src/test_auth.rs
@@ -1,0 +1,673 @@
+//! Explicit authorization-tree tests for sensitive contract entry points.
+//!
+//! These tests verify that every sensitive operation correctly invokes
+//! `require_auth()` on the right address with the right function name and
+//! arguments.  They go beyond simple "wrong caller gets Unauthorized" checks by
+//! asserting the **exact** `AuthorizedInvocation` tree recorded by the Soroban
+//! environment.
+//!
+//! # Pattern
+//!
+//! Each positive test:
+//! 1. Sets up the contract using `mock_all_auths()`.
+//! 2. Calls the function under test.
+//! 3. Calls `env.auths()` and asserts the recorded invocation matches the
+//!    expected `(Address, AuthorizedInvocation)` pair.
+//!
+//! Each negative test creates an environment **without** `mock_all_auths()`,
+//! then attempts the call and expects an `Err` result (auth trap), confirming
+//! that the contract cannot be called without proper authorisation.
+
+extern crate std;
+
+use crate::{NavinShipment, NavinShipmentClient, ShipmentStatus};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger as _},
+    Address, BytesN, Env, IntoVal, Symbol,
+};
+
+// ── Minimal token stub (no-op transfer) ──────────────────────────────────────
+
+#[contract]
+struct MockToken;
+
+#[contractimpl]
+impl MockToken {
+    pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    pub fn transfer_from(
+        _env: Env,
+        _spender: Address,
+        _from: Address,
+        _to: Address,
+        _amount: i128,
+    ) {
+    }
+}
+
+// ── Shared setup helpers ──────────────────────────────────────────────────────
+
+/// Full environment with `mock_all_auths()` active (for positive tests).
+fn setup_env() -> (Env, NavinShipmentClient<'static>, Address, Address) {
+    let (env, admin) = crate::test_utils::setup_env();
+    let token = env.register(MockToken {}, ());
+    let contract_id = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &contract_id);
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+// ── Helper: contract id from client ──────────────────────────────────────────
+fn contract_id(client: &NavinShipmentClient<'static>) -> Address {
+    client.address.clone()
+}
+
+// =============================================================================
+// Admin path — positive auth-tree assertions
+// =============================================================================
+
+/// `add_company` must record an auth invocation for the admin address with the
+/// correct function name and argument list.
+#[test]
+fn test_auth_tree_add_company() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "add_company"),
+                    (admin.clone(), company.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `add_carrier` must record an auth invocation for admin with correct args.
+#[test]
+fn test_auth_tree_add_carrier() {
+    let (env, client, admin, _token) = setup_env();
+    let carrier = Address::generate(&env);
+    let cid = contract_id(&client);
+
+    client.add_carrier(&admin, &carrier);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "add_carrier"),
+                    (admin.clone(), carrier.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `suspend_carrier` must record admin auth with the target carrier address.
+#[test]
+fn test_auth_tree_suspend_carrier() {
+    let (env, client, admin, _token) = setup_env();
+    let carrier = Address::generate(&env);
+    let cid = contract_id(&client);
+
+    client.add_carrier(&admin, &carrier);
+    client.suspend_carrier(&admin, &carrier);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "suspend_carrier"),
+                    (admin.clone(), carrier.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `revoke_role` must record admin auth with the target address.
+#[test]
+fn test_auth_tree_revoke_role() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    client.revoke_role(&admin, &company);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "revoke_role"),
+                    (admin.clone(), company.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `force_cancel_shipment` must record admin auth with the shipment ID and
+/// reason hash, confirming the strict admin-only gate on forced cancellation.
+#[test]
+fn test_auth_tree_force_cancel_shipment() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let reason_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    client.force_cancel_shipment(&admin, &shipment_id, &reason_hash);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "force_cancel_shipment"),
+                    (admin.clone(), shipment_id, reason_hash.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `archive_shipment` must record admin auth with the shipment ID.
+#[test]
+fn test_auth_tree_archive_shipment() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let reason_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+    // Cancel so the shipment is finalized (required before archiving)
+    client.cancel_shipment(&company, &shipment_id, &reason_hash);
+
+    client.archive_shipment(&admin, &shipment_id);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "archive_shipment"),
+                    (admin.clone(), shipment_id).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+// =============================================================================
+// Company path — positive auth-tree assertions
+// =============================================================================
+
+/// `create_shipment` must record the company (sender) auth with all shipment
+/// parameters, confirming no other address can silently create a shipment.
+#[test]
+fn test_auth_tree_create_shipment() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[5u8; 32]);
+    let milestones: soroban_sdk::Vec<(Symbol, u32)> = soroban_sdk::Vec::new(&env);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            company.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "create_shipment"),
+                    (
+                        company.clone(),
+                        receiver.clone(),
+                        carrier.clone(),
+                        data_hash.clone(),
+                        milestones,
+                        deadline,
+                    )
+                        .into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `cancel_shipment` must record the company auth with the shipment ID and
+/// reason hash.
+#[test]
+fn test_auth_tree_cancel_shipment() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let reason_hash = BytesN::from_array(&env, &[9u8; 32]);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    client.cancel_shipment(&company, &shipment_id, &reason_hash);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            company.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "cancel_shipment"),
+                    (company.clone(), shipment_id, reason_hash.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+// =============================================================================
+// Carrier path — positive auth-tree assertions
+// =============================================================================
+
+/// `update_status` must record the carrier auth with shipment ID, new status,
+/// and data hash.
+#[test]
+fn test_auth_tree_update_status() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let status_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    client.update_status(
+        &carrier,
+        &shipment_id,
+        &ShipmentStatus::InTransit,
+        &status_hash,
+    );
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            carrier.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "update_status"),
+                    (
+                        carrier.clone(),
+                        shipment_id,
+                        ShipmentStatus::InTransit,
+                        status_hash.clone(),
+                    )
+                        .into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+/// `handoff_shipment` must record the current carrier auth.
+#[test]
+fn test_auth_tree_handoff_shipment() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier1 = Address::generate(&env);
+    let carrier2 = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let handoff_hash = BytesN::from_array(&env, &[3u8; 32]);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier1);
+    client.add_carrier(&admin, &carrier2);
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier1,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+    // Move to InTransit so handoff is valid
+    client.update_status(
+        &carrier1,
+        &shipment_id,
+        &ShipmentStatus::InTransit,
+        &data_hash,
+    );
+
+    client.handoff_shipment(&carrier1, &carrier2, &shipment_id, &handoff_hash);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            carrier1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "handoff_shipment"),
+                    (
+                        carrier1.clone(),
+                        carrier2.clone(),
+                        shipment_id,
+                        handoff_hash.clone(),
+                    )
+                        .into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+// =============================================================================
+// Receiver path — positive auth-tree assertions
+// =============================================================================
+
+/// `confirm_delivery` must record the receiver auth with the shipment ID and
+/// confirmation hash — the receiver is the only party who can accept delivery.
+#[test]
+fn test_auth_tree_confirm_delivery() {
+    let (env, client, admin, _token) = setup_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let confirm_hash = BytesN::from_array(&env, &[7u8; 32]);
+    let deadline = crate::test_utils::future_deadline(&env, 3_600);
+    let cid = contract_id(&client);
+
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+    client.update_status(
+        &carrier,
+        &shipment_id,
+        &ShipmentStatus::InTransit,
+        &data_hash,
+    );
+
+    client.confirm_delivery(&receiver, &shipment_id, &confirm_hash);
+
+    assert_eq!(
+        env.auths(),
+        std::vec![(
+            receiver.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    cid,
+                    Symbol::new(&env, "confirm_delivery"),
+                    (receiver.clone(), shipment_id, confirm_hash.clone()).into_val(&env),
+                )),
+                sub_invocations: std::vec![],
+            }
+        )]
+    );
+}
+
+// =============================================================================
+// Negative tests — auth mismatch fails predictably
+// =============================================================================
+//
+// IMPORTANT: `mock_all_auths()` persists for the entire `Env` lifetime; once
+// called it cannot be revoked.  Negative tests therefore use completely fresh
+// `Env::default()` instances that *never* have `mock_all_auths()` called.
+//
+// `initialize` does not call `require_auth()`, so a contract can be deployed
+// and initialised without any auth mock.  All subsequent protected functions
+// call `caller.require_auth()` before any other logic, so `try_*` will return
+// `Err` even when no shipment has been set up yet.
+
+/// `add_company` must fail when no auth mock is provided for the admin address.
+#[test]
+fn test_auth_add_company_fails_without_auth() {
+    // Fresh env — mock_all_auths() is NEVER called on this env.
+    let env = Env::default();
+    env.ledger().with_mut(|li| {
+        li.protocol_version = crate::test_utils::DEFAULT_PROTOCOL_VERSION;
+    });
+    env.ledger()
+        .set_timestamp(crate::test_utils::DEFAULT_TIMESTAMP);
+
+    let admin = Address::generate(&env);
+    let company = Address::generate(&env);
+    let token = env.register(MockToken {}, ());
+    let cid = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &cid);
+
+    // initialize does not require_auth — safe without any mock
+    client.initialize(&admin, &token);
+
+    // No auth mock active → admin.require_auth() will fail
+    let result = client.try_add_company(&admin, &company);
+    assert!(
+        result.is_err(),
+        "add_company must fail when admin auth is not provided"
+    );
+}
+
+/// `create_shipment` calls `sender.require_auth()` as its first gate; it must
+/// fail when no auth mock is active even before the role check fires.
+#[test]
+fn test_auth_create_shipment_fails_without_auth() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| {
+        li.protocol_version = crate::test_utils::DEFAULT_PROTOCOL_VERSION;
+    });
+    env.ledger()
+        .set_timestamp(crate::test_utils::DEFAULT_TIMESTAMP);
+
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let admin = Address::generate(&env);
+    let token = env.register(MockToken {}, ());
+    let cid = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &cid);
+    let deadline = env.ledger().timestamp() + 3_600;
+
+    client.initialize(&admin, &token); // no auth needed
+
+    // No mock → company.require_auth() fires and fails before role check
+    let result = client.try_create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+    assert!(
+        result.is_err(),
+        "create_shipment must fail when company auth is not provided"
+    );
+}
+
+/// `update_status` calls `caller.require_auth()` before checking if the
+/// shipment exists; it must fail with no mock even for a non-existent shipment.
+#[test]
+fn test_auth_update_status_fails_without_auth() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| {
+        li.protocol_version = crate::test_utils::DEFAULT_PROTOCOL_VERSION;
+    });
+    env.ledger()
+        .set_timestamp(crate::test_utils::DEFAULT_TIMESTAMP);
+
+    let admin = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let status_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let token = env.register(MockToken {}, ());
+    let cid = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &cid);
+
+    client.initialize(&admin, &token);
+
+    // No mock → carrier.require_auth() fires and fails before shipment lookup
+    let result =
+        client.try_update_status(&carrier, &1u64, &ShipmentStatus::InTransit, &status_hash);
+    assert!(
+        result.is_err(),
+        "update_status must fail when caller auth is not provided"
+    );
+}
+
+/// `confirm_delivery` calls `receiver.require_auth()` before any other logic;
+/// it must fail with no mock.
+#[test]
+fn test_auth_confirm_delivery_fails_without_auth() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| {
+        li.protocol_version = crate::test_utils::DEFAULT_PROTOCOL_VERSION;
+    });
+    env.ledger()
+        .set_timestamp(crate::test_utils::DEFAULT_TIMESTAMP);
+
+    let admin = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let confirm_hash = BytesN::from_array(&env, &[7u8; 32]);
+    let token = env.register(MockToken {}, ());
+    let cid = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &cid);
+
+    client.initialize(&admin, &token);
+
+    // No mock → receiver.require_auth() fires and fails before shipment lookup
+    let result = client.try_confirm_delivery(&receiver, &1u64, &confirm_hash);
+    assert!(
+        result.is_err(),
+        "confirm_delivery must fail when receiver auth is not provided"
+    );
+}
+
+/// `force_cancel_shipment` calls `admin.require_auth()` as its very first gate;
+/// it must fail with no mock.
+#[test]
+fn test_auth_force_cancel_fails_without_auth() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| {
+        li.protocol_version = crate::test_utils::DEFAULT_PROTOCOL_VERSION;
+    });
+    env.ledger()
+        .set_timestamp(crate::test_utils::DEFAULT_TIMESTAMP);
+
+    let admin = Address::generate(&env);
+    let reason_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let token = env.register(MockToken {}, ());
+    let cid = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &cid);
+
+    client.initialize(&admin, &token);
+
+    // No mock → admin.require_auth() fires and fails before shipment lookup
+    let result = client.try_force_cancel_shipment(&admin, &1u64, &reason_hash);
+    assert!(
+        result.is_err(),
+        "force_cancel_shipment must fail when admin auth is not provided"
+    );
+}

--- a/contracts/shipment/src/test_finalization.rs
+++ b/contracts/shipment/src/test_finalization.rs
@@ -97,7 +97,7 @@ fn test_finalization_on_cancel_with_zero_escrow() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #37)")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_mutation_rejected_after_finalization() {
     let (env, client, admin, token_contract) = setup_shipment_env();
     let company = Address::generate(&env);
@@ -123,7 +123,7 @@ fn test_mutation_rejected_after_finalization() {
     let shipment = client.get_shipment(&shipment_id);
     assert!(shipment.finalized);
 
-    // Try to update metadata - should panic with ShipmentFinalized (37)
+    // Try to update metadata - should panic with ShipmentFinalized (38)
     client.set_shipment_metadata(
         &company,
         &shipment_id,

--- a/contracts/shipment/src/test_utils.rs
+++ b/contracts/shipment/src/test_utils.rs
@@ -3,6 +3,34 @@
 //! This module provides helper functions to set up test environments
 //! with explicit protocol version, timestamp, and sequence number
 //! to ensure deterministic behavior across all tests.
+//!
+//! # Usage pattern for time-sensitive tests
+//!
+//! All tests that exercise deadlines, penalties, rate limiting, or proposal
+//! expiry **must** use these helpers instead of ad-hoc ledger mutations so
+//! that the intent is self-documenting and reruns remain deterministic.
+//!
+//! ```text
+//! // ✅ Preferred — intent is clear
+//! test_utils::advance_past_rate_limit(&env);
+//! client.update_status(&carrier, &id, &ShipmentStatus::AtCheckpoint, &h2);
+//!
+//! // ❌ Avoid — magic constant, intent is opaque
+//! env.ledger().with_mut(|l| l.timestamp += 61);
+//! client.update_status(&carrier, &id, &ShipmentStatus::AtCheckpoint, &h2);
+//! ```
+//!
+//! ## Available helpers
+//!
+//! | Helper | Use case |
+//! |---|---|
+//! | [`advance_ledger_time`] | Generic N-second advance |
+//! | [`set_ledger_time`] | Jump to a specific instant |
+//! | [`advance_ledger_sequence`] | Bump sequence by N |
+//! | [`set_ledger_sequence`] | Pin sequence to an exact value |
+//! | [`advance_past_rate_limit`] | Clear 60-s `update_status` window |
+//! | [`advance_past_multisig_expiry`] | Expire a multi-sig proposal |
+//! | [`future_deadline`] | Compute a relative deadline timestamp |
 
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
@@ -52,6 +80,100 @@ pub fn setup_env() -> (Env, Address) {
     (env, admin)
 }
 
+// ── Timestamp helpers ─────────────────────────────────────────────────────────
+
+/// Advance the ledger timestamp by `seconds`.
+///
+/// Use this in place of ad-hoc `env.ledger().with_mut(|l| l.timestamp += N)`
+/// so the intent is explicit and the pattern is consistent across all tests.
+///
+/// # Example
+/// ```text
+/// test_utils::advance_ledger_time(&env, 1001); // push past a 1000-s deadline
+/// client.check_deadline(&shipment_id);
+/// ```
+pub fn advance_ledger_time(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|l| l.timestamp += seconds);
+}
+
+/// Set the ledger timestamp to an explicit absolute value.
+///
+/// Use when a test needs to jump to a specific instant rather than a relative
+/// offset — for example, to land exactly on a deadline+grace boundary.
+///
+/// # Example
+/// ```text
+/// test_utils::set_ledger_time(&env, deadline + grace);
+/// client.check_deadline(&shipment_id); // expires exactly at the boundary
+/// ```
+pub fn set_ledger_time(env: &Env, timestamp: u64) {
+    env.ledger().set_timestamp(timestamp);
+}
+
+// ── Sequence helpers ──────────────────────────────────────────────────────────
+
+/// Advance the ledger sequence number by `count`.
+///
+/// Useful for tests that verify nonce-dependent behaviour or integration
+/// identifiers that increment with each ledger sequence step.
+pub fn advance_ledger_sequence(env: &Env, count: u32) {
+    env.ledger().with_mut(|l| l.sequence_number += count);
+}
+
+/// Set the ledger sequence number to an explicit value.
+///
+/// Pin the sequence to a known state so that tests depending on sequence-based
+/// logic are fully deterministic across reruns.
+pub fn set_ledger_sequence(env: &Env, sequence: u32) {
+    env.ledger().with_mut(|l| l.sequence_number = sequence);
+}
+
+// ── Named scenario helpers ────────────────────────────────────────────────────
+
+/// Advance ledger time by **61 seconds** — just past the 60-second
+/// `min_status_update_interval` — to clear the rate-limit window on
+/// `update_status` calls made by non-admin callers.
+///
+/// # Example
+/// ```text
+/// client.update_status(&carrier, &id, &ShipmentStatus::InTransit, &h1);
+/// test_utils::advance_past_rate_limit(&env);
+/// client.update_status(&carrier, &id, &ShipmentStatus::AtCheckpoint, &h2); // ok
+/// ```
+pub fn advance_past_rate_limit(env: &Env) {
+    advance_ledger_time(env, 61);
+}
+
+/// Advance ledger time by **7 days + 1 second** (604 801 s) — past the
+/// multi-sig proposal expiry window — so that subsequent `approve_action`
+/// or `execute_proposal` calls return `ProposalExpired` (#24).
+///
+/// # Example
+/// ```text
+/// let proposal_id = client.propose_action(&admin1, &action);
+/// test_utils::advance_past_multisig_expiry(&env);
+/// // now approve_action / execute_proposal will return ProposalExpired
+/// ```
+pub fn advance_past_multisig_expiry(env: &Env) {
+    advance_ledger_time(env, 7 * 24 * 60 * 60 + 1); // 604_801 s
+}
+
+/// Return a **future deadline timestamp** that is `secs_from_now` seconds
+/// ahead of the current ledger time.
+///
+/// Prefer this over `env.ledger().timestamp() + N` literals so the
+/// relationship between "now" and the deadline is always obvious.
+///
+/// # Example
+/// ```text
+/// let deadline = test_utils::future_deadline(&env, 3_600); // 1 h from now
+/// let id = client.create_shipment(&company, &receiver, &carrier,
+///                                  &hash, &milestones, &deadline);
+/// ```
+pub fn future_deadline(env: &Env, secs_from_now: u64) -> u64 {
+    env.ledger().timestamp() + secs_from_now
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +198,59 @@ mod tests {
         env.ledger().with_mut(|li| {
             assert_eq!(li.sequence_number, DEFAULT_SEQUENCE_NUMBER);
         });
+    }
+
+    #[test]
+    fn test_advance_ledger_time_increments_timestamp() {
+        let (env, _) = setup_env();
+        let before = env.ledger().timestamp();
+        advance_ledger_time(&env, 100);
+        assert_eq!(env.ledger().timestamp(), before + 100);
+    }
+
+    #[test]
+    fn test_set_ledger_time_pins_timestamp() {
+        let (env, _) = setup_env();
+        set_ledger_time(&env, 999_999);
+        assert_eq!(env.ledger().timestamp(), 999_999);
+    }
+
+    #[test]
+    fn test_advance_ledger_sequence_increments() {
+        let (env, _) = setup_env();
+        let before = env.ledger().sequence();
+        advance_ledger_sequence(&env, 5);
+        assert_eq!(env.ledger().sequence(), before + 5);
+    }
+
+    #[test]
+    fn test_set_ledger_sequence_pins_value() {
+        let (env, _) = setup_env();
+        set_ledger_sequence(&env, 42);
+        assert_eq!(env.ledger().sequence(), 42);
+    }
+
+    #[test]
+    fn test_advance_past_rate_limit_adds_61_seconds() {
+        let (env, _) = setup_env();
+        let before = env.ledger().timestamp();
+        advance_past_rate_limit(&env);
+        assert_eq!(env.ledger().timestamp(), before + 61);
+    }
+
+    #[test]
+    fn test_advance_past_multisig_expiry_adds_seven_days_plus_one() {
+        let (env, _) = setup_env();
+        let before = env.ledger().timestamp();
+        advance_past_multisig_expiry(&env);
+        assert_eq!(env.ledger().timestamp(), before + 604_801);
+    }
+
+    #[test]
+    fn test_future_deadline_returns_offset_from_now() {
+        let (env, _) = setup_env();
+        let now = env.ledger().timestamp();
+        let dl = future_deadline(&env, 3_600);
+        assert_eq!(dl, now + 3_600);
     }
 }


### PR DESCRIPTION

The contract's require_not_finalized check now fires before older domain checks (InvalidStatus, InsufficientFunds, ShipmentAlreadyCompleted) for shipments that are Delivered/Cancelled with zero escrow. Update all affected should_panic expected strings to #38 and fix two clippy warnings: remove duplicated #![cfg(test)] in test_auth.rs and drop unused Ledger import in test.rs.

[CONTRACT] Implement deterministic ledger clock fixture utilities for time-based tests Fixes #183

[CONTRACT] Add contract-auth expectation tests using mock_auths Fixes #184
