### PR TITLE
[291] [CONTRACT] Implement explicit state-machine invariants validator

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -102,6 +102,12 @@ fn validate_milestones(env: &Env, milestones: &Vec<(Symbol, u32)>) -> Result<(),
     Ok(())
 }
 
+fn persist_shipment(env: &Env, shipment: &Shipment) -> Result<(), NavinError> {
+    validation::validate_shipment_invariants(shipment)?;
+    storage::set_shipment(env, shipment);
+    Ok(())
+}
+
 fn checked_add_i128(a: i128, b: i128) -> Result<i128, NavinError> {
     a.checked_add(b).ok_or(NavinError::ArithmeticError)
 }
@@ -355,7 +361,7 @@ fn internal_release_escrow(
                 shipment.escrow_amount = checked_sub_i128(shipment.escrow_amount, actual_release)?;
                 shipment.updated_at = env.ledger().timestamp();
                 shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
-                storage::set_shipment(env, shipment);
+                persist_shipment(env, shipment)?;
                 storage::set_escrow(env, shipment.id, shipment.escrow_amount);
 
                 events::emit_escrow_released(env, shipment.id, &shipment.carrier, actual_release);
@@ -556,7 +562,7 @@ impl NavinShipment {
         shipment.metadata = Some(metadata);
         shipment.updated_at = env.ledger().timestamp();
         shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         Ok(())
     }
 
@@ -1690,7 +1696,7 @@ impl NavinShipment {
             finalized: false,
         };
 
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::set_shipment_counter(&env, shipment_id);
         storage::increment_status_count(&env, &ShipmentStatus::Created);
         storage::increment_active_shipment_count(&env, &sender);
@@ -1798,7 +1804,7 @@ impl NavinShipment {
                 finalized: false,
             };
 
-            storage::set_shipment(&env, &shipment);
+            persist_shipment(&env, &shipment)?;
             storage::set_shipment_counter(&env, shipment_id);
             storage::increment_status_count(&env, &ShipmentStatus::Created);
             storage::increment_active_shipment_count(&env, &sender);
@@ -2012,7 +2018,7 @@ impl NavinShipment {
                 shipment.total_escrow = checked_add_i128(0, amount)?;
                 shipment.updated_at = env.ledger().timestamp();
                 shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
-                storage::set_shipment(&env, &shipment);
+                persist_shipment(&env, &shipment)?;
                 storage::set_escrow(&env, shipment_id, amount);
                 storage::add_total_escrow_volume(&env, amount)?;
                 extend_shipment_ttl(&env, shipment_id);
@@ -2111,7 +2117,7 @@ impl NavinShipment {
         storage::increment_status_count(&env, &shipment.status);
 
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
 
         if shipment.status == ShipmentStatus::Disputed {
             storage::increment_total_disputes(&env);
@@ -2452,7 +2458,7 @@ impl NavinShipment {
         internal_release_escrow(&env, &mut shipment, remaining_escrow)?;
 
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
 
         env.events().publish(
             (Symbol::new(&env, "delivery_confirmed"),),
@@ -2943,7 +2949,7 @@ impl NavinShipment {
         shipment.updated_at = env.ledger().timestamp();
         shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
 
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::decrement_status_count(&env, &old_status);
         storage::increment_status_count(&env, &ShipmentStatus::Cancelled);
 
@@ -2957,7 +2963,7 @@ impl NavinShipment {
             events::emit_escrow_released(&env, shipment_id, &shipment.sender, escrow_amount);
         }
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::remove_escrow_balance(&env, shipment_id);
         extend_shipment_ttl(&env, shipment_id);
 
@@ -3066,7 +3072,7 @@ impl NavinShipment {
         storage::decrement_active_shipment_count(&env, &shipment.sender);
 
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
 
         extend_shipment_ttl(&env, shipment_id);
 
@@ -3207,7 +3213,7 @@ impl NavinShipment {
 
         internal_release_escrow(&env, &mut shipment, escrow_amount)?;
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         events::emit_notification(
             &env,
             &shipment.sender,
@@ -3299,7 +3305,7 @@ impl NavinShipment {
         shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
 
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::decrement_status_count(&env, &old_status);
         storage::increment_status_count(&env, &ShipmentStatus::Cancelled);
 
@@ -3374,7 +3380,7 @@ impl NavinShipment {
         shipment.updated_at = env.ledger().timestamp();
         shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
 
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::decrement_status_count(&env, &old_status);
         storage::increment_status_count(&env, &ShipmentStatus::Disputed);
         storage::increment_total_disputes(&env);
@@ -3498,7 +3504,7 @@ impl NavinShipment {
         storage::decrement_active_shipment_count(&env, &shipment.sender);
 
         finalize_if_settled(&env, &mut shipment);
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::remove_escrow_balance(&env, shipment_id);
         extend_shipment_ttl(&env, shipment_id);
 
@@ -3601,7 +3607,7 @@ impl NavinShipment {
         shipment.updated_at = env.ledger().timestamp();
         shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
 
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         extend_shipment_ttl(&env, shipment_id);
 
         // Emit carrier_handoff event
@@ -4107,7 +4113,7 @@ impl NavinShipment {
                     shipment.escrow_amount = 0;
                     shipment.updated_at = env.ledger().timestamp();
                     shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
-                    storage::set_shipment(&env, &shipment);
+                    persist_shipment(&env, &shipment)?;
 
                     events::emit_escrow_released(
                         &env,
@@ -4139,7 +4145,7 @@ impl NavinShipment {
                     shipment.escrow_amount = 0;
                     shipment.updated_at = env.ledger().timestamp();
                     shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
-                    storage::set_shipment(&env, &shipment);
+                    persist_shipment(&env, &shipment)?;
 
                     events::emit_escrow_refunded(
                         &env,
@@ -4311,7 +4317,7 @@ impl NavinShipment {
         shipment.updated_at = env.ledger().timestamp();
         shipment.integration_nonce = shipment.integration_nonce.saturating_add(1);
 
-        storage::set_shipment(&env, &shipment);
+        persist_shipment(&env, &shipment)?;
         storage::decrement_status_count(&env, &old_status);
         storage::increment_status_count(&env, &ShipmentStatus::Cancelled);
         storage::decrement_active_shipment_count(&env, &shipment.sender);

--- a/contracts/shipment/src/validation.rs
+++ b/contracts/shipment/src/validation.rs
@@ -1,6 +1,6 @@
 use crate::errors::NavinError;
 use crate::storage;
-use crate::types::Shipment;
+use crate::types::{Shipment, ShipmentStatus};
 use soroban_sdk::{xdr::ToXdr, BytesN, Env, Symbol};
 
 /// Maximum reasonable escrow amount (1 quadrillion stroops ≈ 1 billion XLM).
@@ -279,10 +279,43 @@ pub fn preflight_check_shipment_available(
     Ok(shipment)
 }
 
+/// Validate cross-field shipment state-machine invariants.
+///
+/// This validator protects against impossible state combinations and is intended
+/// to be called on every write path before persisting shipment state.
+pub fn validate_shipment_invariants(shipment: &Shipment) -> Result<(), NavinError> {
+    if shipment.total_escrow < 0 || shipment.escrow_amount < 0 {
+        return Err(NavinError::InvalidStatus);
+    }
+
+    if shipment.escrow_amount > shipment.total_escrow {
+        return Err(NavinError::InvalidStatus);
+    }
+
+    if shipment.finalized {
+        let terminal = shipment.status == ShipmentStatus::Delivered
+            || shipment.status == ShipmentStatus::Cancelled;
+        if !terminal || shipment.escrow_amount != 0 {
+            return Err(NavinError::InvalidStatus);
+        }
+    }
+
+    if shipment.status == ShipmentStatus::Disputed && shipment.finalized {
+        return Err(NavinError::InvalidStatus);
+    }
+
+    if shipment.status == ShipmentStatus::Created && !shipment.paid_milestones.is_empty() {
+        return Err(NavinError::InvalidStatus);
+    }
+
+    Ok(())
+}
+
 // Tests
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{testutils::Ledger, BytesN, Env, Symbol};
 
     // validate_hash
@@ -307,6 +340,59 @@ mod tests {
         let env = Env::default();
         let hash: BytesN<32> = BytesN::from_array(&env, &[0xFF_u8; 32]);
         assert_eq!(validate_hash(&hash), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_shipment_invariants_accepts_valid_shipment() {
+        let env = Env::default();
+        let shipment = Shipment {
+            id: 1,
+            sender: soroban_sdk::Address::generate(&env),
+            receiver: soroban_sdk::Address::generate(&env),
+            carrier: soroban_sdk::Address::generate(&env),
+            status: ShipmentStatus::InTransit,
+            data_hash: BytesN::from_array(&env, &[1_u8; 32]),
+            created_at: 100,
+            updated_at: 100,
+            escrow_amount: 10,
+            total_escrow: 10,
+            metadata: None,
+            payment_milestones: soroban_sdk::Vec::new(&env),
+            paid_milestones: soroban_sdk::Vec::new(&env),
+            deadline: 200,
+            integration_nonce: 0,
+            finalized: false,
+        };
+
+        assert_eq!(validate_shipment_invariants(&shipment), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_shipment_invariants_rejects_escrow_greater_than_total() {
+        let env = Env::default();
+        let shipment = Shipment {
+            id: 1,
+            sender: soroban_sdk::Address::generate(&env),
+            receiver: soroban_sdk::Address::generate(&env),
+            carrier: soroban_sdk::Address::generate(&env),
+            status: ShipmentStatus::InTransit,
+            data_hash: BytesN::from_array(&env, &[2_u8; 32]),
+            created_at: 100,
+            updated_at: 100,
+            escrow_amount: 20,
+            total_escrow: 10,
+            metadata: None,
+            payment_milestones: soroban_sdk::Vec::new(&env),
+            paid_milestones: soroban_sdk::Vec::new(&env),
+            deadline: 200,
+            integration_nonce: 0,
+            finalized: false,
+        };
+
+        assert_eq!(
+            validate_shipment_invariants(&shipment),
+            Err(NavinError::InvalidStatus)
+        );
     }
 
     // validate_amount


### PR DESCRIPTION
Closes #291

## What changed
- Added `validate_shipment_invariants(shipment)` in validation logic.
- Enforced invariants across shipment write paths by validating before persistence in the contract flow.
- Added focused invariant tests for valid and invalid state combinations.

## Verification
- `cargo test`