### PR TITLE
feat: add shipment provenance queries (sender, carrier)

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -2098,6 +2098,45 @@ impl NavinShipment {
         Ok(shipment.receiver)
     }
 
+    /// Retrieve the immutable sender (creator) identity for a shipment.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    /// * `shipment_id` - ID of the shipment.
+    ///
+    /// # Returns
+    /// * `Result<Address, NavinError>` - Address that originally created the shipment.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    /// * `NavinError::ShipmentNotFound` - If shipment does not exist.
+    pub fn get_shipment_sender(env: Env, shipment_id: u64) -> Result<Address, NavinError> {
+        require_initialized(&env)?;
+        let shipment =
+            storage::get_shipment(&env, shipment_id).ok_or(NavinError::ShipmentNotFound)?;
+        Ok(shipment.sender)
+    }
+
+    /// Retrieve the immutable carrier identity for a shipment.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    /// * `shipment_id` - ID of the shipment.
+    ///
+    /// # Returns
+    /// * `Result<Address, NavinError>` - Address designated as shipment carrier at creation.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    /// * `NavinError::ShipmentNotFound` - If shipment does not exist.
+    pub fn get_shipment_carrier(env: Env, shipment_id: u64) -> Result<Address, NavinError> {
+        require_initialized(&env)?;
+        let shipment =
+            storage::get_shipment(&env, shipment_id).ok_or(NavinError::ShipmentNotFound)?;
+        Ok(shipment.carrier)
+    }
+
+
     /// Return read-only diagnostics that help operators triage restore requirements.
     ///
     /// This query does not mutate state. It classifies the shipment ID as active,

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -1178,6 +1178,75 @@ fn test_get_shipment_receiver_fails_for_invalid_id() {
     client.get_shipment_receiver(&999);
 }
 
+#[test]
+fn test_get_shipment_sender_returns_sender_for_valid_id() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[13u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    assert_eq!(client.get_shipment_sender(&shipment_id), company);
+}
+
+#[test]
+fn test_get_shipment_carrier_returns_carrier_for_valid_id() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[14u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    assert_eq!(client.get_shipment_carrier(&shipment_id), carrier);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_get_shipment_sender_fails_for_invalid_id() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+
+    client.initialize(&admin, &token_contract);
+
+    client.get_shipment_sender(&999);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_get_shipment_carrier_fails_for_invalid_id() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+
+    client.initialize(&admin, &token_contract);
+
+    client.get_shipment_carrier(&999);
+}
+
+
 // ============= Geofence Event Tests =============
 
 #[test]


### PR DESCRIPTION
**Description:**

This pr closes #334 

This PR adds three read-only helper functions to the shipment contract: `get_shipment_sender`, `get_shipment_receiver`, and `get_shipment_carrier`. These helpers enable frontends and external consumers to inspect immutable shipment provenance data (addresses) directly without the overhead of parsing the full shipment struct.

**Changes:**
- **Contract Implementation (`lib.rs`):**
    - Added `get_shipment_sender`: Returns the sender address for a given shipment ID.
    - Added `get_shipment_carrier`: Returns the carrier address for a given shipment ID.
    - (Verified `get_shipment_receiver` implementation).
- **Consistent Error Handling:**
    - All provenance queries return `NavinError::ShipmentNotFound` if the provided shipment ID does not exist, ensuring consistency with other read paths.
- **Test Coverage (`test.rs`):**
    - Added unit tests for `get_shipment_sender` and `get_shipment_carrier` covering both success cases (valid shipment ID) and failure cases (missing shipment ID).

**Acceptance Criteria Verified:**
- [x] Provenance queries return expected addresses.
- [x] Missing shipment IDs fail with `NavinError::ShipmentNotFound`.
- [x] Added 4 new tests to cover existing and missing shipment IDs for the new helpers.