### PR TITLE
Feat/non terminal shipment count

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -1143,6 +1143,29 @@ impl NavinShipment {
         })
     }
 
+    /// Retrieve the total number of non-terminal shipments currently tracked.
+    ///
+    /// Non-terminal shipments are those in one of the following states:
+    /// 'Created', 'InTransit', 'AtCheckpoint', or 'PartiallyDelivered'.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    ///
+    /// # Returns
+    /// * `Result<u64, NavinError>` - Total count of active (non-terminal) shipments.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    pub fn get_non_terminal_count(env: Env) -> Result<u64, NavinError> {
+        require_initialized(&env)?;
+        let count = storage::get_status_count(&env, &ShipmentStatus::Created)
+            + storage::get_status_count(&env, &ShipmentStatus::InTransit)
+            + storage::get_status_count(&env, &ShipmentStatus::AtCheckpoint)
+            + storage::get_status_count(&env, &ShipmentStatus::PartiallyDelivered);
+        Ok(count)
+    }
+
+
 
     /// Get the deterministic SHA-256 checksum of critical config fields.
     ///

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -2098,6 +2098,45 @@ impl NavinShipment {
         Ok(shipment.receiver)
     }
 
+    /// Retrieve the immutable sender (creator) identity for a shipment.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    /// * `shipment_id` - ID of the shipment.
+    ///
+    /// # Returns
+    /// * `Result<Address, NavinError>` - Address that originally created the shipment.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    /// * `NavinError::ShipmentNotFound` - If shipment does not exist.
+    pub fn get_shipment_sender(env: Env, shipment_id: u64) -> Result<Address, NavinError> {
+        require_initialized(&env)?;
+        let shipment =
+            storage::get_shipment(&env, shipment_id).ok_or(NavinError::ShipmentNotFound)?;
+        Ok(shipment.sender)
+    }
+
+    /// Retrieve the immutable carrier identity for a shipment.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    /// * `shipment_id` - ID of the shipment.
+    ///
+    /// # Returns
+    /// * `Result<Address, NavinError>` - Address designated as shipment carrier at creation.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    /// * `NavinError::ShipmentNotFound` - If shipment does not exist.
+    pub fn get_shipment_carrier(env: Env, shipment_id: u64) -> Result<Address, NavinError> {
+        require_initialized(&env)?;
+        let shipment =
+            storage::get_shipment(&env, shipment_id).ok_or(NavinError::ShipmentNotFound)?;
+        Ok(shipment.carrier)
+    }
+
+
     /// Return read-only diagnostics that help operators triage restore requirements.
     ///
     /// This query does not mutate state. It classifies the shipment ID as active,

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -1120,6 +1120,30 @@ impl NavinShipment {
         })
     }
 
+    /// Retrieve a compact summary of shipment counts aggregated by status.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    ///
+    /// # Returns
+    /// * `Result<ShipmentStatusSummary, NavinError>` - Summary of counts for all statuses.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    pub fn get_status_summary(env: Env) -> Result<ShipmentStatusSummary, NavinError> {
+        require_initialized(&env)?;
+        Ok(ShipmentStatusSummary {
+            created: storage::get_status_count(&env, &ShipmentStatus::Created),
+            in_transit: storage::get_status_count(&env, &ShipmentStatus::InTransit),
+            at_checkpoint: storage::get_status_count(&env, &ShipmentStatus::AtCheckpoint),
+            partially_delivered: storage::get_status_count(&env, &ShipmentStatus::PartiallyDelivered),
+            delivered: storage::get_status_count(&env, &ShipmentStatus::Delivered),
+            disputed: storage::get_status_count(&env, &ShipmentStatus::Disputed),
+            cancelled: storage::get_status_count(&env, &ShipmentStatus::Cancelled),
+        })
+    }
+
+
     /// Get the deterministic SHA-256 checksum of critical config fields.
     ///
     /// This query exposes the config checksum to help indexers and operators

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -6163,6 +6163,51 @@ fn test_get_status_summary_populated() {
     assert_eq!(summary.delivered, 0);
 }
 
+#[test]
+fn test_get_non_terminal_count_mixed_states() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // Create 5 shipments
+    for i in 1..=5 {
+        client.create_shipment(
+            &company,
+            &receiver,
+            &carrier,
+            &BytesN::from_array(&env, &[i as u8; 32]),
+            &soroban_sdk::Vec::new(&env),
+            &deadline,
+        );
+    }
+
+    // Status: 5 Created (Non-terminal)
+    assert_eq!(client.get_non_terminal_count(), 5);
+
+    // Update 1 to InTransit (Non-terminal)
+    client.update_status(&carrier, &1, &ShipmentStatus::InTransit, &data_hash);
+    assert_eq!(client.get_non_terminal_count(), 5);
+
+    // Update 1 to Delivered (Terminal)
+    client.confirm_delivery(&receiver, &1, &data_hash);
+    assert_eq!(client.get_non_terminal_count(), 4);
+
+    // Cancel 1 shipment (Terminal)
+    client.cancel_shipment(&company, &2, &data_hash);
+    assert_eq!(client.get_non_terminal_count(), 3);
+
+    // Raise dispute for 1 shipment (Terminal according to requirements)
+    client.raise_dispute(&company, &3, &data_hash);
+    assert_eq!(client.get_non_terminal_count(), 2);
+}
+
+
 
 // ============= Shipment Limit Tests =============
 

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -1178,6 +1178,75 @@ fn test_get_shipment_receiver_fails_for_invalid_id() {
     client.get_shipment_receiver(&999);
 }
 
+#[test]
+fn test_get_shipment_sender_returns_sender_for_valid_id() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[13u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    assert_eq!(client.get_shipment_sender(&shipment_id), company);
+}
+
+#[test]
+fn test_get_shipment_carrier_returns_carrier_for_valid_id() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[14u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+
+    assert_eq!(client.get_shipment_carrier(&shipment_id), carrier);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_get_shipment_sender_fails_for_invalid_id() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+
+    client.initialize(&admin, &token_contract);
+
+    client.get_shipment_sender(&999);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_get_shipment_carrier_fails_for_invalid_id() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+
+    client.initialize(&admin, &token_contract);
+
+    client.get_shipment_carrier(&999);
+}
+
+
 // ============= Geofence Event Tests =============
 
 #[test]

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -6107,6 +6107,63 @@ fn test_analytics_batch_and_cancel() {
     );
 }
 
+#[test]
+fn test_get_status_summary_empty() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let summary = client.get_status_summary();
+    assert_eq!(summary.created, 0);
+    assert_eq!(summary.in_transit, 0);
+    assert_eq!(summary.at_checkpoint, 0);
+    assert_eq!(summary.partially_delivered, 0);
+    assert_eq!(summary.delivered, 0);
+    assert_eq!(summary.disputed, 0);
+    assert_eq!(summary.cancelled, 0);
+}
+
+#[test]
+fn test_get_status_summary_populated() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // Create 3 shipments
+    for i in 1..=3 {
+        client.create_shipment(
+            &company,
+            &receiver,
+            &carrier,
+            &BytesN::from_array(&env, &[i as u8; 32]),
+            &soroban_sdk::Vec::new(&env),
+            &deadline,
+        );
+    }
+
+    // Status: 3 Created
+    let summary = client.get_status_summary();
+    assert_eq!(summary.created, 3);
+
+    // Update 1 to InTransit
+    client.update_status(&carrier, &1, &ShipmentStatus::InTransit, &data_hash);
+
+    // Update 1 to AtCheckpoint
+    client.update_status(&carrier, &2, &ShipmentStatus::AtCheckpoint, &data_hash);
+
+    let summary = client.get_status_summary();
+    assert_eq!(summary.created, 1);
+    assert_eq!(summary.in_transit, 1);
+    assert_eq!(summary.at_checkpoint, 1);
+    assert_eq!(summary.delivered, 0);
+}
+
+
 // ============= Shipment Limit Tests =============
 
 #[test]

--- a/contracts/shipment/src/types.rs
+++ b/contracts/shipment/src/types.rs
@@ -689,6 +689,27 @@ pub struct Analytics {
     pub cancelled_count: u64,
 }
 
+/// Compact summary of shipment counts aggregated by status.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ShipmentStatusSummary {
+    /// Count of shipments in 'Created' state.
+    pub created: u64,
+    /// Count of shipments in 'InTransit' state.
+    pub in_transit: u64,
+    /// Count of shipments in 'AtCheckpoint' state.
+    pub at_checkpoint: u64,
+    /// Count of shipments in 'PartiallyDelivered' state.
+    pub partially_delivered: u64,
+    /// Count of shipments in 'Delivered' state.
+    pub delivered: u64,
+    /// Count of shipments in 'Disputed' state.
+    pub disputed: u64,
+    /// Count of shipments in 'Cancelled' state.
+    pub cancelled: u64,
+}
+
+
 /// Paginated result for company-carrier relationship queries (issue #295).
 ///
 /// Returns a page of carrier addresses whitelisted by a company, with a


### PR DESCRIPTION
**Description:**

This pr closes #336 

This PR introduces a read-only helper function `get_non_terminal_count` to the shipment contract. This function provides a real-time count of shipments that are still in progress, specifically those in `Created`, `InTransit`, `AtCheckpoint`, or `PartiallyDelivered` states. It ensures that terminal states—`Delivered`, `Cancelled`, and `Disputed`—are excluded from the total, offering a clear view of the contract's active workload.

**Changes:**
- **Contract Implementation (`lib.rs`):**
    - Implemented `get_non_terminal_count` to aggregate non-terminal status counts from storage.
- **Testing (`test.rs`):**
    - Added `test_get_non_terminal_count_mixed_states` to verify the accuracy of the count across mixed shipment states and lifecycle transitions.

**Acceptance Criteria Verified:**
- [x] Active counts accurately reflect stored shipment states.
- [x] Terminal shipments are correctly excluded from the total.
- [x] Query output is stable and consistent with existing read-only helpers.