### PR TITLE
feat: add require_shipment_exists preflight helper (#343)

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -572,6 +572,17 @@ fn require_shipment(env: &Env, shipment_id: u64) -> Result<Shipment, NavinError>
     storage::get_shipment(env, shipment_id).ok_or(NavinError::ShipmentNotFound)
 }
 
+/// Preflight existence check: returns `Err(ShipmentNotFound)` early if the
+/// shipment does not exist, without loading the full record. Use this at the
+/// top of mutation handlers so callers receive a clear domain error before any
+/// deeper logic runs.
+fn require_shipment_exists(env: &Env, shipment_id: u64) -> Result<(), NavinError> {
+    if !storage::has_persistent_shipment(env, shipment_id) {
+        return Err(NavinError::ShipmentNotFound);
+    }
+    Ok(())
+}
+
 /// Require that `caller` is the assigned carrier for a shipment (or admin).
 /// Returns the shipment on success.
 fn require_carrier_for_shipment(
@@ -2456,6 +2467,7 @@ impl NavinShipment {
     ) -> Result<(), NavinError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
+        require_shipment_exists(&env, shipment_id)?;
         caller.require_auth();
 
         // Validate hash before storage
@@ -3766,6 +3778,7 @@ impl NavinShipment {
     ) -> Result<(), NavinError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
+        require_shipment_exists(&env, shipment_id)?;
         caller.require_auth();
 
         // Validate hash before storage

--- a/contracts/shipment/src/test_precondition_guards.rs
+++ b/contracts/shipment/src/test_precondition_guards.rs
@@ -207,6 +207,65 @@ mod tests {
         assert!(matches!(result, Err(Ok(NavinError::ShipmentNotFound))));
     }
 
+    // ── require_shipment_exists preflight ────────────────────────────────────
+
+    #[test]
+    fn preflight_update_status_missing_shipment_returns_not_found() {
+        let (env, client, _admin, _company, carrier) = setup();
+        let hash = make_hash(&env, 20);
+        let result = client.try_update_status(&carrier, &9999, &ShipmentStatus::InTransit, &hash);
+        assert_eq!(result, Err(Ok(NavinError::ShipmentNotFound)));
+    }
+
+    #[test]
+    fn preflight_cancel_shipment_missing_shipment_returns_not_found() {
+        let (env, client, admin, _company, _carrier) = setup();
+        let hash = make_hash(&env, 21);
+        let result = client.try_cancel_shipment(&admin, &9999, &hash);
+        assert_eq!(result, Err(Ok(NavinError::ShipmentNotFound)));
+    }
+
+    #[test]
+    fn preflight_update_status_existing_shipment_passes_through() {
+        let (env, client, _admin, company, carrier) = setup();
+        let receiver = Address::generate(&env);
+        let hash = make_hash(&env, 22);
+        let deadline = future_deadline(&env);
+        let id = client.create_shipment(
+            &company,
+            &receiver,
+            &carrier,
+            &hash,
+            &Vec::new(&env),
+            &deadline,
+            &None,
+        );
+        let hash2 = make_hash(&env, 23);
+        // Should not return ShipmentNotFound — passes the preflight and proceeds to status logic.
+        let result = client.try_update_status(&carrier, &id, &ShipmentStatus::InTransit, &hash2);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn preflight_cancel_shipment_existing_shipment_passes_through() {
+        let (env, client, _admin, company, carrier) = setup();
+        let receiver = Address::generate(&env);
+        let hash = make_hash(&env, 24);
+        let deadline = future_deadline(&env);
+        let id = client.create_shipment(
+            &company,
+            &receiver,
+            &carrier,
+            &hash,
+            &Vec::new(&env),
+            &deadline,
+            &None,
+        );
+        let hash2 = make_hash(&env, 25);
+        let result = client.try_cancel_shipment(&company, &id, &hash2);
+        assert!(result.is_ok());
+    }
+
     // ── require_not_finalized ────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Add a dedicated existence-check helper that returns Err(ShipmentNotFound) early, before auth or deeper logic runs, so callers get a clear domain error on missing shipments.

- Add  in lib.rs using
- Wire it into  and  before require_auth
- Add four tests in test_precondition_guards.rs covering missing/existing shipments for both mutation paths

## Description

<!-- Provide a brief description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test additions or improvements

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

Fixes #(issue)

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass locally

## Screenshots (if appropriate add screenshots of tests)

<!-- Add screenshots or code examples if relevant -->

## Checklist

<!-- Mark completed items with an "x" -->

### Before Submitting

- [ ] I have run `make pre-commit` and all checks pass
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### CI Requirements (must pass)

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] `cargo build --target wasm32-unknown-unknown --release` succeeds

## Additional Notes
closes #343 
<!-- Add any other context about the PR here -->
