### PR TITLE
feat(shipment): enforce sequential milestone payout order

### DIFF
--- a/contracts/shipment/src/fuzz_milestone_releases.rs
+++ b/contracts/shipment/src/fuzz_milestone_releases.rs
@@ -17,9 +17,9 @@
 
 extern crate std;
 
-use crate::{NavinShipment, NavinShipmentClient};
+use crate::{NavinError, NavinShipment, NavinShipmentClient, ShipmentStatus};
 use soroban_sdk::{
-    contract, contractimpl,
+    contract, contractimpl, symbol_short,
     testutils::{Address as _, Ledger as _},
     Address, BytesN, Env, Symbol, Vec,
 };
@@ -387,6 +387,88 @@ fn fuzz_milestone_random_valid_percentages() {
         assert!(
             result.is_ok(),
             "Random valid milestones ({p1}+{p2}=100) must be accepted"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Property 6: Sequential payout order is enforced — Issue #450
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// For each random iteration:
+/// - out-of-order release (beta/gamma before alpha) is rejected with InvalidStatus
+/// - in-order releases all succeed and drain escrow to zero
+#[test]
+fn fuzz_milestone_order_enforced() {
+    let (env, client, admin) = setup();
+
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut rng: u64 = 0xB000_F000_A000_0600;
+    let iterations = fuzz_iterations();
+
+    for i in 0..iterations {
+        let seed = xorshift64(&mut rng);
+        env.ledger().with_mut(|l| l.timestamp += 3);
+
+        let receiver = Address::generate(&env);
+        let data_hash = hash_from_seed(&env, seed + i as u64);
+        let deadline = env.ledger().timestamp() + 86_400 * 30;
+
+        let mut milestones = Vec::new(&env);
+        milestones.push_back((Symbol::new(&env, "alpha"), 40u32));
+        milestones.push_back((Symbol::new(&env, "beta"), 35u32));
+        milestones.push_back((Symbol::new(&env, "gamma"), 25u32));
+
+        let id = client.create_shipment(
+            &company,
+            &receiver,
+            &carrier,
+            &data_hash,
+            &milestones,
+            &deadline,
+        );
+
+        let deposit = ((seed % 9_000) + 1_000) as i128;
+        client.deposit_escrow(&company, &id, &deposit);
+
+        env.as_contract(&client.address, || {
+            let mut s = crate::storage::get_shipment(&env, id).unwrap();
+            s.status = ShipmentStatus::InTransit;
+            crate::storage::set_shipment(&env, &s);
+        });
+
+        // beta before alpha must fail
+        assert_eq!(
+            client.try_release_milestone_payment(&carrier, &id, &symbol_short!("beta")),
+            Err(Ok(NavinError::InvalidStatus)),
+            "iteration {i}: beta before alpha must be rejected"
+        );
+
+        // gamma before alpha must fail
+        assert_eq!(
+            client.try_release_milestone_payment(&carrier, &id, &symbol_short!("gamma")),
+            Err(Ok(NavinError::InvalidStatus)),
+            "iteration {i}: gamma before alpha must be rejected"
+        );
+
+        // in-order succeeds
+        client.release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+        client.release_milestone_payment(&carrier, &id, &symbol_short!("beta"));
+        client.release_milestone_payment(&carrier, &id, &symbol_short!("gamma"));
+
+        let shipment = client.get_shipment(&id);
+        assert_eq!(
+            shipment.escrow_amount, 0,
+            "iteration {i}: escrow must be zero after all payouts"
+        );
+        assert_eq!(
+            shipment.milestones_completed.len(),
+            3,
+            "iteration {i}: all 3 milestones must be completed"
         );
     }
 }

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -47,6 +47,8 @@ mod types;
 mod validation;
 
 #[cfg(test)]
+mod test_archive_restore_consistency;
+#[cfg(test)]
 mod test_auth;
 #[cfg(test)]
 mod test_auto_dispute;
@@ -55,13 +57,21 @@ mod test_carrier_relationship;
 #[cfg(test)]
 mod test_counter_overflow;
 #[cfg(test)]
+mod test_counter_overflow;
+#[cfg(test)]
 mod test_creation_quota;
 #[cfg(test)]
+mod test_deadline_grace;
+#[cfg(test)]
 mod test_diagnostics;
+#[cfg(test)]
+mod test_escrow_arithmetic;
 #[cfg(test)]
 mod test_hash_domain_separation;
 #[cfg(test)]
 mod test_iot_verification;
+#[cfg(test)]
+mod test_milestone_payout_order;
 #[cfg(test)]
 mod test_panic_free_invariants;
 #[cfg(test)]
@@ -77,9 +87,9 @@ mod test_signature_argument_ordering;
 #[cfg(test)]
 mod test_suspension;
 #[cfg(test)]
-mod test_symbol_validation;
+mod test_suspension_cascade;
 #[cfg(test)]
-mod test_escrow_arithmetic;
+mod test_symbol_validation;
 #[cfg(test)]
 mod test_ttl_health;
 #[cfg(test)]
@@ -87,17 +97,9 @@ mod test_utils;
 #[cfg(test)]
 mod test_verification;
 #[cfg(test)]
-mod test_zero_amount_escrow;
-#[cfg(test)]
-mod test_counter_overflow;
-#[cfg(test)]
 mod test_whitelist_multicompany;
 #[cfg(test)]
-mod test_suspension_cascade;
-#[cfg(test)]
-mod test_archive_restore_consistency;
-#[cfg(test)]
-mod test_deadline_grace;
+mod test_zero_amount_escrow;
 
 // ── Fuzz / property-based test harnesses ─────────────────────────────────────
 #[cfg(test)]
@@ -3651,6 +3653,14 @@ impl NavinShipment {
 
         if already_completed {
             return Err(NavinError::MilestoneAlreadyPaid);
+        }
+
+        // Enforce sequential ordering: all prior milestones must be paid first.
+        if idx > 0 {
+            let completed_count = shipment.milestones_completed.len() as usize;
+            if completed_count < idx {
+                return Err(NavinError::InvalidStatus);
+            }
         }
 
         let ms_config = shipment.payment_milestones.get(idx as u32).unwrap();

--- a/contracts/shipment/src/test_consistency.rs
+++ b/contracts/shipment/src/test_consistency.rs
@@ -1088,8 +1088,7 @@ fn test_carrier_whitelist_storage_key_correctness() {
 
     // Verify internal storage using the canonical key order
     env.as_contract(&client.address, || {
-        let canonical_forward =
-            crate::storage::is_carrier_whitelisted(&env, &company, &carrier);
+        let canonical_forward = crate::storage::is_carrier_whitelisted(&env, &company, &carrier);
         assert!(
             canonical_forward,
             "canonical forward lookup (company, carrier) must succeed"
@@ -1208,7 +1207,10 @@ fn test_carrier_whitelist_nonexistent_pair_returns_false() {
     let result2 = client.is_carrier_whitelisted(&company, &carrier);
 
     assert!(!result1, "non-existent pair should return false");
-    assert_eq!(result1, result2, "non-existent pair query must be deterministic");
+    assert_eq!(
+        result1, result2,
+        "non-existent pair query must be deterministic"
+    );
 }
 
 /// Test: Whitelist state persists across multiple operations on other entities.
@@ -1329,19 +1331,6 @@ fn test_carrier_whitelist_remove_idempotent() {
         !client.is_carrier_whitelisted(&company, &carrier),
         "carrier should not be whitelisted after multiple removes"
     );
-}n_sdk::Vec;
-
-    let mut visited: Vec<u64> = Vec::new(env);
-    let mut path: Vec<u64> = Vec::new(env);
-
-    for i in 0..new_deps.len() {
-        if let Some(dep_id) = new_deps.get(i) {
-            if has_cycle_recursive(env, dep_id, start_id, &mut visited, &mut path) {
-                return true;
-            }
-        }
-    }
-    false
 }
 
 /// Recursive helper for cycle detection using DFS.

--- a/contracts/shipment/src/test_milestone_payout_order.rs
+++ b/contracts/shipment/src/test_milestone_payout_order.rs
@@ -1,0 +1,324 @@
+//! # Milestone Payout Order Tests — Issue #450
+//!
+//! Verifies that milestone payouts are enforced in sequential order:
+//! - Milestones must be released in the order they are declared.
+//! - Attempting to release a later milestone before an earlier one is rejected.
+//! - Remaining milestone state updates correctly after each payout.
+
+#![cfg(test)]
+
+use crate::{NavinError, NavinShipment, NavinShipmentClient, ShipmentStatus};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Symbol, Vec};
+
+// ── Mock token ────────────────────────────────────────────────────────────────
+
+#[contract]
+struct MilestoneOrderToken;
+
+#[contractimpl]
+impl MilestoneOrderToken {
+    pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, NavinShipmentClient<'static>, Address) {
+    let (env, admin) = crate::test_utils::setup_env();
+    let token = env.register(MilestoneOrderToken, ());
+    let client = NavinShipmentClient::new(&env, &env.register(NavinShipment, ()));
+    client.initialize(&admin, &token);
+    (env, client, admin)
+}
+
+fn data_hash(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+/// Build a shipment with three sequential milestones (alpha 40 %, beta 35 %, gamma 25 %)
+/// and an escrow deposit. Returns (shipment_id, company, carrier).
+fn create_milestone_shipment(
+    env: &Env,
+    client: &NavinShipmentClient<'static>,
+    admin: &Address,
+) -> (u64, Address, Address) {
+    let company = Address::generate(env);
+    let carrier = Address::generate(env);
+    let receiver = Address::generate(env);
+
+    client.add_company(admin, &company);
+    client.add_carrier(admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+
+    let mut milestones = Vec::new(env);
+    milestones.push_back((symbol_short!("alpha"), 40u32));
+    milestones.push_back((symbol_short!("beta"), 35u32));
+    milestones.push_back((symbol_short!("gamma"), 25u32));
+
+    let deadline = env.ledger().timestamp() + 86_400;
+    let id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash(env, 0xAB),
+        &milestones,
+        &deadline,
+    );
+
+    // Fund the escrow (10_000 units).
+    client.deposit_escrow(&company, &id, &10_000);
+
+    // Move to InTransit so the carrier can record milestones / release payments.
+    env.as_contract(&client.address, || {
+        let mut s = crate::storage::get_shipment(env, id).unwrap();
+        s.status = ShipmentStatus::InTransit;
+        crate::storage::set_shipment(env, &s);
+    });
+
+    (id, company, carrier)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Releasing the first milestone (index 0) always succeeds.
+#[test]
+fn test_release_first_milestone_succeeds() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    let result = client.try_release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+    assert!(
+        result.is_ok(),
+        "first milestone must be releasable: {result:?}"
+    );
+
+    let shipment = client.get_shipment(&id);
+    assert_eq!(shipment.milestones_completed.len(), 1);
+    assert_eq!(shipment.paid_milestones.len(), 1);
+}
+
+/// Releasing in sequential order (alpha → beta → gamma) must succeed for all steps.
+#[test]
+fn test_release_milestones_in_order_succeeds() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("beta"));
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("gamma"));
+
+    let shipment = client.get_shipment(&id);
+    assert_eq!(shipment.milestones_completed.len(), 3);
+    // After all milestones, escrow should be fully drained.
+    assert_eq!(shipment.escrow_amount, 0);
+}
+
+/// Attempting to release the second milestone (beta) before the first (alpha) is rejected.
+#[test]
+fn test_release_out_of_order_second_before_first_fails() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    let result = client.try_release_milestone_payment(&carrier, &id, &symbol_short!("beta"));
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidStatus)),
+        "releasing beta before alpha must be rejected"
+    );
+}
+
+/// Attempting to release the third milestone (gamma) before the first two is rejected.
+#[test]
+fn test_release_out_of_order_third_first_fails() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    let result = client.try_release_milestone_payment(&carrier, &id, &symbol_short!("gamma"));
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidStatus)),
+        "releasing gamma before alpha and beta must be rejected"
+    );
+}
+
+/// After alpha is paid, beta can be released but gamma is still blocked.
+#[test]
+fn test_release_third_blocked_after_one_paid() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    // Pay alpha first.
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+
+    // gamma still blocked (index 2, only 1 completed).
+    let result = client.try_release_milestone_payment(&carrier, &id, &symbol_short!("gamma"));
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidStatus)),
+        "gamma must still be blocked when only alpha is paid"
+    );
+
+    // beta is allowed now.
+    assert!(
+        client
+            .try_release_milestone_payment(&carrier, &id, &symbol_short!("beta"))
+            .is_ok(),
+        "beta must succeed after alpha is paid"
+    );
+}
+
+/// Attempting to release the same milestone twice returns MilestoneAlreadyPaid.
+#[test]
+fn test_release_same_milestone_twice_fails() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+    let result = client.try_release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::MilestoneAlreadyPaid)),
+        "releasing alpha a second time must return MilestoneAlreadyPaid"
+    );
+}
+
+/// milestones_completed grows by one with each successful sequential release.
+#[test]
+fn test_completed_count_grows_sequentially() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    assert_eq!(client.get_shipment(&id).milestones_completed.len(), 0);
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+    assert_eq!(client.get_shipment(&id).milestones_completed.len(), 1);
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("beta"));
+    assert_eq!(client.get_shipment(&id).milestones_completed.len(), 2);
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("gamma"));
+    assert_eq!(client.get_shipment(&id).milestones_completed.len(), 3);
+}
+
+/// Each milestone releases its declared percentage of total_escrow.
+#[test]
+fn test_milestone_payout_amounts_are_proportional() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    let total = 10_000i128;
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("alpha"));
+    // 40 % of 10_000 = 4_000 released; remaining = 6_000
+    assert_eq!(client.get_shipment(&id).escrow_amount, total - 4_000);
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("beta"));
+    // 35 % of 10_000 = 3_500 released; remaining = 2_500
+    assert_eq!(
+        client.get_shipment(&id).escrow_amount,
+        total - 4_000 - 3_500
+    );
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("gamma"));
+    // 25 % of 10_000 = 2_500 released; remaining = 0
+    assert_eq!(client.get_shipment(&id).escrow_amount, 0);
+}
+
+/// A single-milestone shipment (100 %) releases fully in one call.
+#[test]
+fn test_single_milestone_full_release() {
+    let (env, client, admin) = setup();
+
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back((symbol_short!("done"), 100u32));
+
+    let id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash(&env, 0xCC),
+        &milestones,
+        &(env.ledger().timestamp() + 86_400),
+    );
+
+    client.deposit_escrow(&company, &id, &5_000);
+
+    env.as_contract(&client.address, || {
+        let mut s = crate::storage::get_shipment(&env, id).unwrap();
+        s.status = ShipmentStatus::InTransit;
+        crate::storage::set_shipment(&env, &s);
+    });
+
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("done"));
+    assert_eq!(client.get_shipment(&id).escrow_amount, 0);
+    assert_eq!(client.get_shipment(&id).milestones_completed.len(), 1);
+}
+
+/// A two-milestone shipment (60/40): releasing beta before alpha must be rejected.
+#[test]
+fn test_two_milestone_order_enforced() {
+    let (env, client, admin) = setup();
+
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back((symbol_short!("first"), 60u32));
+    milestones.push_back((symbol_short!("second"), 40u32));
+
+    let id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash(&env, 0xDD),
+        &milestones,
+        &(env.ledger().timestamp() + 86_400),
+    );
+
+    client.deposit_escrow(&company, &id, &1_000);
+
+    env.as_contract(&client.address, || {
+        let mut s = crate::storage::get_shipment(&env, id).unwrap();
+        s.status = ShipmentStatus::InTransit;
+        crate::storage::set_shipment(&env, &s);
+    });
+
+    // second before first must fail
+    let result = client.try_release_milestone_payment(&carrier, &id, &symbol_short!("second"));
+    assert_eq!(result, Err(Ok(NavinError::InvalidStatus)));
+
+    // first succeeds
+    client.release_milestone_payment(&carrier, &id, &symbol_short!("first"));
+
+    // second now allowed
+    assert!(client
+        .try_release_milestone_payment(&carrier, &id, &symbol_short!("second"))
+        .is_ok());
+}
+
+/// Non-existent milestone name returns InvalidShipmentInput.
+#[test]
+fn test_unknown_milestone_rejected() {
+    let (env, client, admin) = setup();
+    let (id, _company, carrier) = create_milestone_shipment(&env, &client, &admin);
+
+    let bogus: Symbol = Symbol::new(&env, "bogus");
+    let result = client.try_release_milestone_payment(&carrier, &id, &bogus);
+    assert_eq!(result, Err(Ok(NavinError::InvalidShipmentInput)));
+}


### PR DESCRIPTION
## Summary

- Adds sequential ordering enforcement to `release_milestone_payment`: milestone at index N is rejected with `InvalidStatus` unless all prior milestones (0..N-1) are completed
- Adds `test_milestone_payout_order` module with 9 targeted tests covering in-order success, out-of-order rejection, partial progress blocking, payout amounts, and edge-case fixtures (single/two/three milestones)
- Adds `fuzz_milestone_order_enforced` property test to `fuzz_milestone_releases` — runs 50 iterations asserting that out-of-order release always fails and full sequential release always drains escrow to zero
- Fixes a garbled merge artifact in `test_consistency.rs` that caused a hard compile error blocking all test compilation

## Test plan

- [ ] `cargo fmt --all` — formatting applied to changed files
- [ ] `cargo test -p shipment milestone` — all 9 new order tests pass + fuzz property test
- [ ] Ordering enforcement: `test_release_out_of_order_second_before_first_fails`, `test_release_out_of_order_third_first_fails`, `test_release_third_blocked_after_one_paid` confirm `InvalidStatus` is returned
- [ ] In-order: `test_release_milestones_in_order_succeeds`, `test_milestone_payout_amounts_are_proportional`, `test_completed_count_grows_sequentially` pass
- [ ] Edge cases: `test_single_milestone_full_release`, `test_two_milestone_order_enforced`, `test_unknown_milestone_rejected`, `test_release_same_milestone_twice_fails` pass

Closes #450
Closes #451
Closes #449
Closes #438