### PR TITLE
Add validation and tests for issues #506, #507, #508, #530

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -51,6 +51,8 @@ mod test_archive_restore_consistency;
 #[cfg(test)]
 mod test_auth;
 #[cfg(test)]
+mod test_auth_matrix;
+#[cfg(test)]
 mod test_auto_dispute;
 #[cfg(test)]
 mod test_carrier_relationship;

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -4962,6 +4962,9 @@ impl NavinShipment {
 
         let now = env.ledger().timestamp();
         let config = config::get_config(&env);
+        if config.proposal_expiry_seconds == 0 {
+            return Err(NavinError::InvalidConfig);
+        }
         let expires_at = now + config.proposal_expiry_seconds;
 
         let mut approvals = soroban_sdk::Vec::new(&env);

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -11524,3 +11524,64 @@ fn test_clear_finalization_emits_audit_trail() {
     let shipment = client.get_shipment(&shipment_id);
     assert!(!shipment.finalized);
 }
+
+// ── [ISSUE #506] get_admin in multi-admin configurations ─────────────────────
+
+#[test]
+fn test_get_admin_returns_primary_admin_after_multisig_init() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let admin2 = Address::generate(&env);
+    let admin3 = Address::generate(&env);
+    let mut admins = soroban_sdk::Vec::new(&env);
+    admins.push_back(admin.clone());
+    admins.push_back(admin2.clone());
+    admins.push_back(admin3.clone());
+    client.init_multisig(&admin, &admins, &2);
+
+    assert_eq!(
+        client.get_admin(),
+        admin,
+        "get_admin must return the primary admin set during initialize"
+    );
+}
+
+#[test]
+fn test_get_admin_consistent_across_queries_in_multisig_mode() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let admin2 = Address::generate(&env);
+    let mut admins = soroban_sdk::Vec::new(&env);
+    admins.push_back(admin.clone());
+    admins.push_back(admin2.clone());
+    client.init_multisig(&admin, &admins, &2);
+
+    let first = client.get_admin();
+    let second = client.get_admin();
+    assert_eq!(first, second, "repeated get_admin calls must return the same address");
+    assert_eq!(first, admin);
+}
+
+#[test]
+fn test_get_admin_unaffected_by_additional_multisig_admins() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let before = client.get_admin();
+
+    let admin2 = Address::generate(&env);
+    let admin3 = Address::generate(&env);
+    let mut admins = soroban_sdk::Vec::new(&env);
+    admins.push_back(admin.clone());
+    admins.push_back(admin2.clone());
+    admins.push_back(admin3.clone());
+    client.init_multisig(&admin, &admins, &3);
+
+    let after = client.get_admin();
+    assert_eq!(
+        before, after,
+        "get_admin must not change after init_multisig"
+    );
+}

--- a/contracts/shipment/src/test_auth_matrix.rs
+++ b/contracts/shipment/src/test_auth_matrix.rs
@@ -1,0 +1,105 @@
+//! Tests for issue #508 — operators are blocked from escrow release and refund.
+//!
+//! Verifies that an address registered only as an Operator cannot call
+//! `release_escrow` or `refund_escrow`, and that both calls fail with
+//! `NavinError::Unauthorized`.
+
+#[cfg(test)]
+mod tests {
+    use crate::{test_utils, NavinError, NavinShipment, NavinShipmentClient};
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, BytesN, Env, Vec};
+
+    #[contract]
+    struct MockToken;
+
+    #[contractimpl]
+    impl MockToken {
+        pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+        pub fn decimals(_env: Env) -> u32 {
+            7
+        }
+    }
+
+    fn setup() -> (Env, NavinShipmentClient<'static>, Address) {
+        let (env, admin) = test_utils::setup_env();
+        let token = env.register(MockToken, ());
+        let client = NavinShipmentClient::new(&env, &env.register(NavinShipment, ()));
+        client.initialize(&admin, &token);
+        (env, client, admin)
+    }
+
+    fn create_shipment(
+        env: &Env,
+        client: &NavinShipmentClient,
+        admin: &Address,
+    ) -> (u64, Address, Address, Address) {
+        let company = Address::generate(env);
+        let receiver = Address::generate(env);
+        let carrier = Address::generate(env);
+        client.add_company(admin, &company);
+        client.add_carrier(admin, &carrier);
+        client.add_carrier_to_whitelist(&company, &carrier);
+        let deadline = test_utils::future_deadline(env, 7_200);
+        let id = client.create_shipment(
+            &company,
+            &receiver,
+            &carrier,
+            &BytesN::from_array(env, &[1u8; 32]),
+            &Vec::new(env),
+            &deadline,
+        );
+        (id, company, receiver, carrier)
+    }
+
+    #[test]
+    fn operator_cannot_release_escrow() {
+        let (env, client, admin) = setup();
+        let (shipment_id, _company, _receiver, _carrier) = create_shipment(&env, &client, &admin);
+
+        let operator = Address::generate(&env);
+        client.add_operator(&admin, &operator);
+
+        let result = client.try_release_escrow(&operator, &shipment_id);
+        assert_eq!(
+            result,
+            Err(Ok(NavinError::Unauthorized)),
+            "operator must be rejected from release_escrow"
+        );
+    }
+
+    #[test]
+    fn operator_cannot_refund_escrow() {
+        let (env, client, admin) = setup();
+        let (shipment_id, _company, _receiver, _carrier) = create_shipment(&env, &client, &admin);
+
+        let operator = Address::generate(&env);
+        client.add_operator(&admin, &operator);
+
+        let result = client.try_refund_escrow(&operator, &shipment_id);
+        assert_eq!(
+            result,
+            Err(Ok(NavinError::Unauthorized)),
+            "operator must be rejected from refund_escrow"
+        );
+    }
+
+    #[test]
+    fn operator_blocked_regardless_of_shipment_state() {
+        let (env, client, admin) = setup();
+        let (shipment_id, company, _receiver, _carrier) = create_shipment(&env, &client, &admin);
+
+        let operator = Address::generate(&env);
+        client.add_operator(&admin, &operator);
+
+        // Cancel the shipment (valid state for refund) and still verify operator is blocked.
+        let cancel_hash = BytesN::from_array(&env, &[9u8; 32]);
+        client.cancel_shipment(&company, &shipment_id, &cancel_hash);
+
+        let result = client.try_refund_escrow(&operator, &shipment_id);
+        assert_eq!(
+            result,
+            Err(Ok(NavinError::Unauthorized)),
+            "operator must be rejected from refund_escrow even on a cancelled shipment"
+        );
+    }
+}

--- a/contracts/shipment/src/test_consistency.rs
+++ b/contracts/shipment/src/test_consistency.rs
@@ -1217,3 +1217,74 @@ fn test_upgrade_preserves_analytics_counters() {
         assert_eq!(escrow2, 500);
     });
 }
+
+// ── [ISSUE #530] get_version read-only method update tests ──────────────────
+
+#[test]
+fn test_get_version_returns_initial_version_one() {
+    let (_env, client, _admin, _token) = setup();
+    assert_eq!(
+        client.get_version(),
+        1,
+        "get_version must return 1 immediately after initialize"
+    );
+}
+
+#[test]
+fn test_get_version_reflects_simulated_upgrade() {
+    let (env, client, _admin, _token) = setup();
+
+    let initial = client.get_version();
+
+    env.as_contract(&client.address, || {
+        crate::storage::set_version(&env, initial + 1);
+    });
+
+    let after = client.get_version();
+    assert_eq!(
+        after,
+        initial + 1,
+        "get_version must reflect the incremented value after simulated upgrade"
+    );
+}
+
+#[test]
+fn test_get_version_increments_match_target_after_upgrade() {
+    let (env, client, admin, _token) = setup();
+
+    let initial = client.get_version();
+    let target = initial + 1;
+
+    let wasm: &[u8] = include_bytes!("../test_wasms/upgrade_test.wasm");
+    let new_wasm_hash = env.deployer().upload_contract_wasm(wasm);
+    let contract_id = client.address.clone();
+    client.upgrade(&admin, &new_wasm_hash, &target);
+
+    env.as_contract(&contract_id, || {
+        let post = crate::storage::get_version(&env);
+        assert_eq!(
+            post, target,
+            "version must equal the target_version passed to upgrade"
+        );
+    });
+}
+
+#[test]
+fn test_get_version_is_stable_across_repeated_reads() {
+    let (env, client, _admin, _token) = setup();
+
+    let v1 = client.get_version();
+
+    env.as_contract(&client.address, || {
+        crate::storage::set_version(&env, 5);
+    });
+
+    let v2 = client.get_version();
+    let v3 = client.get_version();
+    let v4 = client.get_version();
+
+    assert_eq!(v2, v3, "repeated get_version must return the same value");
+    assert_eq!(v3, v4, "repeated get_version must return the same value");
+    assert_eq!(v2, 5);
+    let _ = v1;
+}

--- a/contracts/shipment/src/test_proposal_digest.rs
+++ b/contracts/shipment/src/test_proposal_digest.rs
@@ -665,5 +665,49 @@ mod tests {
             "Proposal must be expired after 7-day threshold"
         );
     }
+
+    // ── [ISSUE #507] Zero-duration proposal expiry rejection tests ─────────────
+
+    /// Test: propose_action is rejected when proposal_expiry_seconds is zero.
+    /// Bypasses update_config validation to directly set a zero-duration expiry
+    /// in config storage, then verifies propose_action returns InvalidConfig.
+    #[test]
+    fn propose_action_rejected_when_expiry_seconds_is_zero() {
+        let (env, client, admin, _admin2) = setup_multisig();
+
+        // Bypass config validation and force proposal_expiry_seconds = 0.
+        env.as_contract(&client.address, || {
+            let mut cfg = crate::config::get_config(&env);
+            cfg.proposal_expiry_seconds = 0;
+            crate::config::set_config(&env, &cfg);
+        });
+
+        let action = crate::types::AdminAction::TransferAdmin(Address::generate(&env));
+        let result = client.try_propose_action(&admin, &action);
+        assert_eq!(
+            result,
+            Err(Ok(NavinError::InvalidConfig)),
+            "zero-duration expiry must be rejected"
+        );
+    }
+
+    /// Test: propose_action succeeds when proposal_expiry_seconds is positive.
+    /// Verifies that the check does not reject valid positive-duration proposals.
+    #[test]
+    fn propose_action_succeeds_with_positive_expiry_seconds() {
+        let (env, client, admin, _admin2) = setup_multisig();
+
+        // Explicitly set a positive expiry (1 hour) to confirm acceptance.
+        let mut cfg = client.get_contract_config();
+        cfg.proposal_expiry_seconds = 3_600;
+        client.update_config(&admin, &cfg);
+
+        let action = crate::types::AdminAction::TransferAdmin(Address::generate(&env));
+        let result = client.try_propose_action(&admin, &action);
+        assert!(
+            result.is_ok(),
+            "positive-duration expiry must be accepted"
+        );
+    }
 }
 


### PR DESCRIPTION
## Summary

- Reject zero-duration proposal expiry in `propose_action` and add rejection tests
- Add operator escrow release/refund restriction tests with a new `test_auth_matrix` module
- Add `get_admin` query tests for multi-admin (multi-sig) configurations
- Add `get_version` read-only method update tests including post-upgrade version tracking

## Changes

### Issue #507 — Zero-duration proposal expiry validation
- `lib.rs`: Added guard in `propose_action` — returns `NavinError::InvalidConfig` when `proposal_expiry_seconds == 0`
- `test_proposal_digest.rs`: Added two tests: rejection of zero-duration expiry (via storage bypass) and acceptance of a valid positive-duration expiry

### Issue #508 — Operator escrow release/refund restriction
- `lib.rs`: Registered `test_auth_matrix` module
- `test_auth_matrix.rs` (new): Three tests verifying that an Operator-role address is rejected with `NavinError::Unauthorized` from both `release_escrow` and `refund_escrow`

### Issue #506 — `get_admin` in multi-admin configurations
- `test.rs`: Three tests verifying `get_admin` returns the primary admin set during `initialize` regardless of how many multi-sig admins are configured via `init_multisig`

### Issue #530 — `get_version` post-upgrade tracking
- `test_consistency.rs`: Four tests: initial version is 1, version reflects a simulated upgrade, version matches `target_version` after a real WASM upgrade, and repeated reads are stable

## Closes

Closes #507
Closes #508
Closes #506
Closes #530