### PR TITLE
feat(shipment): tests for token-decimals query, suspension batch lockout, and AtCheckpoint loop rejection (#540, #541, #542)

### DIFF
--- a/contracts/shipment/src/test_settlement_transitions.rs
+++ b/contracts/shipment/src/test_settlement_transitions.rs
@@ -486,3 +486,48 @@ fn test_valid_and_invalid_transitions_guard_boundary() {
         .unwrap_err();
     assert_eq!(err, crate::NavinError::InvalidStatus);
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// ISSUE #542 — AtCheckpoint → AtCheckpoint transitions must be rejected
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Direct `AtCheckpoint -> AtCheckpoint` transition must be rejected by the
+/// pure transition matrix. A shipment must hop back to `InTransit` before
+/// entering a new checkpoint, preventing duplicate checkpoint records.
+#[test]
+fn issue_542_at_checkpoint_to_at_checkpoint_is_invalid_in_matrix() {
+    assert!(
+        !ShipmentStatus::AtCheckpoint.is_valid_transition(&ShipmentStatus::AtCheckpoint),
+        "AtCheckpoint -> AtCheckpoint must be rejected by is_valid_transition"
+    );
+}
+
+/// The high-level `validate_shipment_transition` helper (used by all
+/// status-changing entry points) must surface the rejection as
+/// `NavinError::InvalidStatus` so callers get a typed, machine-checkable
+/// error rather than a generic panic.
+#[test]
+fn issue_542_at_checkpoint_to_at_checkpoint_returns_invalid_status() {
+    use crate::validate_shipment_transition;
+    let err = validate_shipment_transition(
+        &ShipmentStatus::AtCheckpoint,
+        &ShipmentStatus::AtCheckpoint,
+    )
+    .unwrap_err();
+    assert_eq!(err, crate::NavinError::InvalidStatus);
+}
+
+/// Sanity-check the legitimate hop: `AtCheckpoint -> InTransit -> AtCheckpoint`
+/// must remain valid in both directions so the validation rule only blocks
+/// the direct loop, not the canonical workflow.
+#[test]
+fn issue_542_at_checkpoint_via_in_transit_to_at_checkpoint_is_valid() {
+    assert!(
+        ShipmentStatus::AtCheckpoint.is_valid_transition(&ShipmentStatus::InTransit),
+        "AtCheckpoint -> InTransit must remain valid"
+    );
+    assert!(
+        ShipmentStatus::InTransit.is_valid_transition(&ShipmentStatus::AtCheckpoint),
+        "InTransit -> AtCheckpoint must remain valid"
+    );
+}

--- a/contracts/shipment/src/test_suspension_cascade.rs
+++ b/contracts/shipment/src/test_suspension_cascade.rs
@@ -290,4 +290,146 @@ mod tests {
             "reactivated company must be able to create new shipments"
         );
     }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // ISSUE #541 — suspension must block bulk / batch shipment creation
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// Build a `Vec<ShipmentInput>` of `n` shipments all addressed from the
+    /// same company to freshly generated receivers/carriers so each batch
+    /// element passes the per-item input validators in `create_shipments_batch`.
+    fn build_batch_inputs(
+        env: &Env,
+        company_carrier: &Address,
+        n: u32,
+    ) -> soroban_sdk::Vec<crate::types::ShipmentInput> {
+        let mut v = soroban_sdk::Vec::new(env);
+        let deadline = env.ledger().timestamp() + 86_400;
+        for i in 0..n {
+            v.push_back(crate::types::ShipmentInput {
+                receiver: Address::generate(env),
+                carrier: company_carrier.clone(),
+                data_hash: BytesN::from_array(env, &[(0xA0 + i) as u8; 32]),
+                payment_milestones: soroban_sdk::Vec::new(env),
+                deadline,
+            });
+        }
+        v
+    }
+
+    /// A registered, non-suspended company must be able to create a batch
+    /// of shipments via `create_shipments_batch`. Anchors the negative tests
+    /// below — without this baseline a suspension-induced failure could be
+    /// confused with a generic batch-validation failure.
+    #[test]
+    fn issue_541_active_company_can_create_batch() {
+        let (env, client, admin) = setup();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+        client.add_carrier_to_whitelist(&company, &carrier);
+
+        let inputs = build_batch_inputs(&env, &carrier, 3);
+        let result = client.try_create_shipments_batch(&company, &inputs);
+        assert!(
+            result.is_ok(),
+            "non-suspended company must be able to create a shipment batch (baseline)"
+        );
+        let ids = result.unwrap().unwrap();
+        assert_eq!(
+            ids.len(),
+            3,
+            "batch must return one shipment id per input element"
+        );
+    }
+
+    /// Suspending a company must immediately block subsequent
+    /// `create_shipments_batch` calls with `NavinError::CompanySuspended` —
+    /// the same error path that `create_shipment` (single) already produces.
+    #[test]
+    fn issue_541_suspended_company_cannot_create_batch() {
+        let (env, client, admin) = setup();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+        client.add_carrier_to_whitelist(&company, &carrier);
+
+        client.suspend_company(&admin, &company);
+
+        let inputs = build_batch_inputs(&env, &carrier, 3);
+        let result = client.try_create_shipments_batch(&company, &inputs);
+        assert!(
+            result.is_err(),
+            "suspended company must not be able to create a batch"
+        );
+        assert_eq!(
+            result,
+            Err(Ok(crate::NavinError::CompanySuspended)),
+            "the typed CompanySuspended error must surface to callers"
+        );
+    }
+
+    /// Suspending a company while another shipment is in-flight must still
+    /// block batch creations. The in-flight shipment is unrelated state and
+    /// must remain untouched (its status is independently asserted by
+    /// `suspend_company_does_not_auto_cancel_in_flight_shipment` above).
+    #[test]
+    fn issue_541_suspension_blocks_batch_even_with_in_flight_shipment() {
+        let (env, client, admin) = setup();
+        let (company, _, carrier, in_flight_id, _) =
+            create_in_transit_shipment(&env, &client, &admin);
+        assert_eq!(
+            client.get_shipment(&in_flight_id).status,
+            ShipmentStatus::InTransit
+        );
+
+        client.suspend_company(&admin, &company);
+
+        let inputs = build_batch_inputs(&env, &carrier, 2);
+        let result = client.try_create_shipments_batch(&company, &inputs);
+        assert!(
+            result.is_err(),
+            "suspended company must not create batches even while another shipment is in-flight"
+        );
+        assert_eq!(result, Err(Ok(crate::NavinError::CompanySuspended)));
+
+        // The in-flight shipment must remain in its pre-suspension state —
+        // suspension blocks the actor, it does not mutate unrelated state.
+        assert_eq!(
+            client.get_shipment(&in_flight_id).status,
+            ShipmentStatus::InTransit,
+            "in-flight shipment status must remain InTransit after suspension"
+        );
+    }
+
+    /// After reactivation a previously-suspended company must regain the
+    /// ability to call `create_shipments_batch` — the lockout is reversible.
+    #[test]
+    fn issue_541_reactivated_company_can_resume_batch_creation() {
+        let (env, client, admin) = setup();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+        client.add_carrier_to_whitelist(&company, &carrier);
+
+        client.suspend_company(&admin, &company);
+        let blocked = client.try_create_shipments_batch(
+            &company,
+            &build_batch_inputs(&env, &carrier, 1),
+        );
+        assert!(blocked.is_err());
+
+        client.reactivate_company(&admin, &company);
+        let after = client.try_create_shipments_batch(
+            &company,
+            &build_batch_inputs(&env, &carrier, 1),
+        );
+        assert!(
+            after.is_ok(),
+            "reactivated company must be able to create batches again"
+        );
+    }
 }

--- a/contracts/shipment/src/test_token_compatibility.rs
+++ b/contracts/shipment/src/test_token_compatibility.rs
@@ -464,3 +464,76 @@ fn test_get_expected_token_decimals_matches_setting() {
         "get_expected_token_decimals must return 7 decimals"
     );
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// ISSUE #540 — `get_expected_token_decimals` query unit tests
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Querying the expected token decimals before the contract has been
+/// initialized must return `NotInitialized`, not a default value. This
+/// protects callers from acting on a stale / unconfigured contract.
+#[test]
+fn issue_540_get_expected_token_decimals_rejected_before_init() {
+    let env = Env::default();
+    let contract_id = env.register(NavinShipment, ());
+    let client = NavinShipmentClient::new(&env, &contract_id);
+
+    let result = client.try_get_expected_token_decimals();
+    assert!(
+        result.is_err(),
+        "get_expected_token_decimals must fail before initialize is called"
+    );
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::NotInitialized)),
+        "pre-init query must return NavinError::NotInitialized"
+    );
+}
+
+/// After initialization, the query must return exactly 7 — the value
+/// hard-coded in `EXPECTED_TOKEN_DECIMALS` and enforced everywhere escrow
+/// math normalizes token amounts.
+#[test]
+fn issue_540_get_expected_token_decimals_returns_seven_after_init() {
+    let ctx = setup_test(TokenVariant::StellarAsset);
+    assert_eq!(
+        ctx.shipment_client.get_expected_token_decimals(),
+        7,
+        "configured expected decimals must equal the EXPECTED_TOKEN_DECIMALS constant (7)"
+    );
+}
+
+/// The query is read-only — it must return the same value across multiple
+/// invocations and is independent of the underlying token variant (SAC vs.
+/// custom NavinToken) since it reports the *expected* decimals policy, not
+/// the actual decimals of any specific token.
+#[test]
+fn issue_540_get_expected_token_decimals_is_stable_across_calls_and_variants() {
+    let sac = setup_test(TokenVariant::StellarAsset);
+    let d1 = sac.shipment_client.get_expected_token_decimals();
+    let d2 = sac.shipment_client.get_expected_token_decimals();
+    let d3 = sac.shipment_client.get_expected_token_decimals();
+    assert_eq!(d1, d2);
+    assert_eq!(d2, d3);
+    assert_eq!(d1, 7);
+
+    let custom = setup_test(TokenVariant::Custom);
+    assert_eq!(
+        custom.shipment_client.get_expected_token_decimals(),
+        7,
+        "expected decimals policy must not depend on the token variant under test"
+    );
+}
+
+/// The query exposes the on-chain `EXPECTED_TOKEN_DECIMALS` constant
+/// itself. A direct constant comparison guards against accidental drift
+/// between the public query and the value enforced by `deposit_escrow`.
+#[test]
+fn issue_540_get_expected_token_decimals_matches_internal_constant() {
+    let ctx = setup_test(TokenVariant::StellarAsset);
+    assert_eq!(
+        ctx.shipment_client.get_expected_token_decimals(),
+        crate::types::EXPECTED_TOKEN_DECIMALS,
+        "the public query must always return the same value the contract enforces internally"
+    );
+}

--- a/contracts/shipment/src/types.rs
+++ b/contracts/shipment/src/types.rs
@@ -276,6 +276,13 @@ impl ShipmentStatus {
             (Self::InTransit, Self::Delivered) => true,
             (Self::InTransit, Self::Disputed) => true,
             (Self::InTransit, Self::Cancelled) => true,
+            // Issue #542 — a shipment must return to `InTransit` before
+            // entering another checkpoint, so direct `AtCheckpoint ->
+            // AtCheckpoint` hops are explicitly rejected here rather than
+            // falling through to the catch-all `_ => false` arm. This
+            // protects against off-by-one workflow code that would
+            // otherwise silently record duplicate checkpoint entries.
+            (Self::AtCheckpoint, Self::AtCheckpoint) => false,
             (Self::AtCheckpoint, Self::InTransit) => true,
             (Self::AtCheckpoint, Self::PartiallyDelivered) => true,
             (Self::AtCheckpoint, Self::Delivered) => true,


### PR DESCRIPTION
## Summary
Three smart-contract testing tasks, all touching `contracts/shipment/src/`.

### Issue #540 — `get_expected_token_decimals` query unit tests
4 new tests in `test_token_compatibility.rs`:
| Test | What it locks in |
|---|---|
| `..._rejected_before_init` | pre-init query returns `NavinError::NotInitialized` |
| `..._returns_seven_after_init` | configured value matches the hard-coded 7 |
| `..._is_stable_across_calls_and_variants` | idempotent + independent of the SAC vs custom-token variant under test |
| `..._matches_internal_constant` | public query == `EXPECTED_TOKEN_DECIMALS` constant (guards against drift between the query and the enforcer in `deposit_escrow`) |

### Issue #541 — suspension cascade on batch creation
4 new integration tests in `test_suspension_cascade.rs`:
| Test | What it locks in |
|---|---|
| `..._active_company_can_create_batch` | baseline non-suspension path (anchors the negative tests) |
| `..._suspended_company_cannot_create_batch` | typed `CompanySuspended` error surfaces on `create_shipments_batch` |
| `..._suspension_blocks_batch_even_with_in_flight_shipment` | in-flight state remains `InTransit` — suspension blocks the actor, not unrelated state |
| `..._reactivated_company_can_resume_batch_creation` | lockout is reversible |

Helper `build_batch_inputs` keeps each test focused on the lockout behavior rather than per-item batch plumbing.

### Issue #542 — `AtCheckpoint` → `AtCheckpoint` rejection
- `types.rs`: explicit `(Self::AtCheckpoint, Self::AtCheckpoint) => false` arm in `is_valid_transition`. Behavior is already rejected via the catch-all arm, but making it explicit guards against accidental matrix edits and makes the prohibition discoverable at the call site.
- 3 new tests in `test_settlement_transitions.rs`:
  - matrix-level rejection check
  - `validate_shipment_transition` surfaces `NavinError::InvalidStatus`
  - sanity-check that `AtCheckpoint -> InTransit -> AtCheckpoint` remains valid in both directions

## Acceptance Criteria

**#540**
- [x] Decimals query tests implemented
- [x] Configurations matching asserted
- [x] `cargo test` passes (for the new tests)
- [x] `cargo clippy` clean on lib

**#541**
- [x] Suspension checks verified on batch creations
- [x] State lockouts validated in tests (in-flight shipment remains unchanged)
- [x] `cargo test` passes (for the new tests)
- [x] `cargo clippy` clean on lib

**#542**
- [x] Transition loop checks implemented
- [x] Boundary tests added to `test_settlement_transitions.rs`
- [x] `cargo test` passes (for the new tests)
- [x] `cargo clippy` clean on lib

## Verification
```bash
cargo test -p shipment --lib issue_5            # ✅ 11/11 new tests pass
cargo clippy -p shipment --lib -- -D warnings   # ✅ clean
```

Two pre-existing test failures remain on `main` and are unrelated to this change:
- `test_auth_matrix::tests::operator_blocked_regardless_of_shipment_state`
- `test_proposal_digest::tests::expired_proposal_storage_can_be_cleaned`

Verified by checking out `main` and running each in isolation — both fail without any of this PR's code present.

Closes #540
Closes #541
Closes #542