### PR TITLE
feat(shipment): reject duplicate carrier whitelist registrations (#539)

### DIFF
--- a/contracts/shipment/src/error_map.rs
+++ b/contracts/shipment/src/error_map.rs
@@ -446,6 +446,12 @@ pub fn error_info(error: NavinError) -> ContractErrorInfo {
             NoRetry,
             "Evidence not found or index out of bounds.",
         ),
+        NavinError::CarrierAlreadyWhitelisted => (
+            68,
+            InvalidState,
+            NoRetry,
+            "Carrier is already on the company's whitelist; duplicate addition is not allowed.",
+        ),
     };
 
     ContractErrorInfo {

--- a/contracts/shipment/src/errors.rs
+++ b/contracts/shipment/src/errors.rs
@@ -149,4 +149,10 @@ pub enum NavinError {
     NoteNotFound = 66,
     /// Evidence not found or index out of bounds.
     EvidenceNotFound = 67,
+    /// Issue #539 — caller attempted to add a carrier to a company's
+    /// whitelist that is already present. The whitelist is set-like;
+    /// duplicate additions are rejected with this dedicated error so
+    /// off-chain monitors can distinguish a no-op from a real failure
+    /// without falling back on the generic `AlreadyInitialized` code.
+    CarrierAlreadyWhitelisted = 68,
 }

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -1371,6 +1371,14 @@ impl NavinShipment {
         company.require_auth();
         require_role(&env, &company, Role::Company)?;
 
+        // Issue #539 — reject duplicate whitelist additions. Without this
+        // check the storage write is silently idempotent and emits a
+        // spurious `add_wl` event, making it impossible for off-chain
+        // monitors to distinguish a re-add from a first-time add.
+        if storage::is_carrier_whitelisted(&env, &company, &carrier) {
+            return Err(NavinError::CarrierAlreadyWhitelisted);
+        }
+
         storage::add_carrier_to_whitelist(&env, &company, &carrier);
 
         env.events().publish(

--- a/contracts/shipment/src/test_carrier_relationship.rs
+++ b/contracts/shipment/src/test_carrier_relationship.rs
@@ -293,4 +293,106 @@ mod tests {
         assert_eq!(page.carriers.get(0).unwrap(), c1);
         assert_eq!(page.carriers.get(1).unwrap(), c3);
     }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // ISSUE #539 — duplicate carrier whitelist registration rejection
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// Baseline: a fresh `add_carrier_to_whitelist` succeeds and the
+    /// carrier is then visible via `is_carrier_whitelisted`. Anchors the
+    /// duplicate-rejection tests below — without this we couldn't tell a
+    /// duplicate-rejection failure apart from a generic add failure.
+    #[test]
+    fn issue_539_first_whitelist_add_succeeds() {
+        let (env, client, admin) = setup();
+        let (company, carrier) = add_company_and_carrier(&env, &client, &admin);
+
+        let result = client.try_add_carrier_to_whitelist(&company, &carrier);
+        assert!(
+            result.is_ok(),
+            "first whitelist add for a fresh carrier must succeed"
+        );
+        assert!(
+            client.is_carrier_whitelisted(&company, &carrier),
+            "carrier must be visible on the whitelist after a successful add"
+        );
+    }
+
+    /// Re-adding an already-whitelisted carrier must return the typed
+    /// `CarrierAlreadyWhitelisted` error instead of silently succeeding.
+    /// This is the core acceptance criterion of #539.
+    #[test]
+    fn issue_539_duplicate_whitelist_add_returns_typed_error() {
+        let (env, client, admin) = setup();
+        let (company, carrier) = add_company_and_carrier(&env, &client, &admin);
+
+        client.add_carrier_to_whitelist(&company, &carrier);
+
+        let result = client.try_add_carrier_to_whitelist(&company, &carrier);
+        assert_eq!(
+            result,
+            Err(Ok(crate::NavinError::CarrierAlreadyWhitelisted)),
+            "duplicate add must surface the typed CarrierAlreadyWhitelisted error"
+        );
+    }
+
+    /// Whitelist state must remain consistent after a rejected duplicate
+    /// add. The first entry still exists; no second copy is recorded.
+    /// Guards against a future refactor that returns the error AFTER
+    /// mutating storage.
+    #[test]
+    fn issue_539_whitelist_state_unchanged_after_duplicate_rejection() {
+        let (env, client, admin) = setup();
+        let (company, carrier) = add_company_and_carrier(&env, &client, &admin);
+
+        client.add_carrier_to_whitelist(&company, &carrier);
+        let _ = client.try_add_carrier_to_whitelist(&company, &carrier);
+
+        assert!(
+            client.is_carrier_whitelisted(&company, &carrier),
+            "whitelist entry must persist after a duplicate add is rejected"
+        );
+    }
+
+    /// The duplicate-rejection rule is per (company, carrier) pair. The
+    /// same carrier whitelisted by a DIFFERENT company is a fresh
+    /// (company, carrier) tuple and must still be addable.
+    #[test]
+    fn issue_539_same_carrier_can_be_whitelisted_by_different_companies() {
+        let (env, client, admin) = setup();
+        let company_a = Address::generate(&env);
+        let company_b = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        client.add_company(&admin, &company_a);
+        client.add_company(&admin, &company_b);
+        client.add_carrier(&admin, &carrier);
+
+        client.add_carrier_to_whitelist(&company_a, &carrier);
+        let result = client.try_add_carrier_to_whitelist(&company_b, &carrier);
+        assert!(
+            result.is_ok(),
+            "the duplicate-add rule is scoped per (company, carrier) and must not block a different company"
+        );
+        assert!(client.is_carrier_whitelisted(&company_a, &carrier));
+        assert!(client.is_carrier_whitelisted(&company_b, &carrier));
+    }
+
+    /// After remove + re-add the carrier must be addable again. The
+    /// duplicate-rejection rule must only fire on *current* membership,
+    /// not on historical presence.
+    #[test]
+    fn issue_539_can_readd_after_remove() {
+        let (env, client, admin) = setup();
+        let (company, carrier) = add_company_and_carrier(&env, &client, &admin);
+
+        client.add_carrier_to_whitelist(&company, &carrier);
+        client.remove_carrier_from_whitelist(&company, &carrier);
+        assert!(!client.is_carrier_whitelisted(&company, &carrier));
+
+        let result = client.try_add_carrier_to_whitelist(&company, &carrier);
+        assert!(
+            result.is_ok(),
+            "carrier must be re-addable after being removed from the whitelist"
+        );
+    }
 }

--- a/contracts/shipment/src/test_consistency.rs
+++ b/contracts/shipment/src/test_consistency.rs
@@ -1104,8 +1104,14 @@ fn test_carrier_whitelist_parameter_order_matters() {
     );
 }
 
-/// Test: Repeated add operations are idempotent.
-/// This ensures adding the same carrier multiple times has no adverse effects.
+/// Test: Repeated add operations are now rejected (issue #539).
+///
+/// Originally this contract treated duplicate whitelist adds as silently
+/// idempotent. Issue #539 hardened that path: the first add succeeds, and
+/// subsequent adds for the same (company, carrier) pair return
+/// `CarrierAlreadyWhitelisted`. The underlying state remains consistent
+/// after the rejection — exactly one entry persists, and a single remove
+/// clears it as before.
 #[test]
 fn test_carrier_whitelist_add_idempotent() {
     let (env, client, admin, _) = setup();
@@ -1115,22 +1121,35 @@ fn test_carrier_whitelist_add_idempotent() {
     client.add_company(&admin, &company);
     client.add_carrier(&admin, &carrier);
 
-    // Add carrier multiple times
-    client.add_carrier_to_whitelist(&company, &carrier);
-    client.add_carrier_to_whitelist(&company, &carrier);
+    // First add succeeds.
     client.add_carrier_to_whitelist(&company, &carrier);
 
-    // Should still be whitelisted (no error, state is correct)
-    assert!(
-        client.is_carrier_whitelisted(&company, &carrier),
-        "carrier should be whitelisted after multiple adds"
+    // Subsequent adds for the same pair are now rejected with a typed error.
+    let dup = client.try_add_carrier_to_whitelist(&company, &carrier);
+    assert_eq!(
+        dup,
+        Err(Ok(crate::NavinError::CarrierAlreadyWhitelisted)),
+        "duplicate whitelist add must surface CarrierAlreadyWhitelisted (issue #539)"
+    );
+    let dup2 = client.try_add_carrier_to_whitelist(&company, &carrier);
+    assert_eq!(
+        dup2,
+        Err(Ok(crate::NavinError::CarrierAlreadyWhitelisted)),
+        "rejection must be stable across multiple duplicate attempts"
     );
 
-    // Remove once should clear it
+    // State is unchanged — the original entry persists.
+    assert!(
+        client.is_carrier_whitelisted(&company, &carrier),
+        "carrier must remain whitelisted after rejected duplicate adds"
+    );
+
+    // Single remove still clears it (no phantom extra entries from the
+    // rejected adds).
     client.remove_carrier_from_whitelist(&company, &carrier);
     assert!(
         !client.is_carrier_whitelisted(&company, &carrier),
-        "carrier should not be whitelisted after single remove"
+        "single remove must clear the carrier after rejected duplicates"
     );
 }
 


### PR DESCRIPTION
## Summary
Hardens `add_carrier_to_whitelist` to reject duplicate additions instead of silently succeeding.

## Behavior change
`add_carrier_to_whitelist(company, carrier)` now returns the typed `NavinError::CarrierAlreadyWhitelisted = 68` when called for a `(company, carrier)` pair that is already on the whitelist. Previously the call was silently idempotent, which made it impossible for off-chain monitors to distinguish a re-add from a first-time add and produced a spurious `add_wl` event on every duplicate call.

## Changes
- `errors.rs`: new variant `CarrierAlreadyWhitelisted = 68`.
- `error_map.rs`: mapping entry (category `InvalidState`, `NoRetry`).
- `lib.rs::add_carrier_to_whitelist`: presence check via `storage::is_carrier_whitelisted` runs immediately after the auth/role guards; returns the new error before any storage write or event emission.

## Tests
**5 new tests** in `test_carrier_relationship.rs`:
| Test | What it locks in |
|---|---|
| `..._first_whitelist_add_succeeds` | baseline anchor — first add ok |
| `..._duplicate_whitelist_add_returns_typed_error` | typed `CarrierAlreadyWhitelisted` surfaces (core acceptance criterion) |
| `..._whitelist_state_unchanged_after_duplicate_rejection` | exactly one entry persists; no phantom writes |
| `..._same_carrier_can_be_whitelisted_by_different_companies` | rule scoped per `(company, carrier)` — not globally |
| `..._can_readd_after_remove` | rule fires on *current* membership, not historical |

**1 existing test rewritten** in `test_consistency.rs`:
- `test_carrier_whitelist_add_idempotent` previously asserted the silently-idempotent behavior this issue calls out as a bug. It now asserts the new contract: first add ok, subsequent adds typed-rejected, single remove still clears.

## Acceptance Criteria
- [x] Duplicate whitelisting checks implemented (`add_carrier_to_whitelist` rejects re-adds with `CarrierAlreadyWhitelisted`)
- [x] Re-registration tests added (5 new + 1 rewritten)
- [x] `cargo test` passes for the new + rewritten tests
- [x] `cargo clippy` has no warnings on the lib

## Verification
```bash
cargo test -p shipment --lib issue_539           # ✅ 5/5 new tests pass
cargo test -p shipment --lib test_carrier_whitelist_add_idempotent  # ✅ rewritten test passes
cargo test -p shipment --lib                     # ✅ 1193 pass; 2 pre-existing failures unrelated to this change
cargo clippy -p shipment --lib -- -D warnings    # ✅ clean
```

The 2 pre-existing failures (`test_auth_matrix::tests::operator_blocked_regardless_of_shipment_state` and `test_proposal_digest::tests::expired_proposal_storage_can_be_cleaned`) are present on `main` without this PR's code — verified by checking out `main` and running them in isolation.

Closes #539