### PR TITLE
feat

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -165,9 +165,9 @@ fn validate_milestones(env: &Env, milestones: &Vec<(Symbol, u32)>) -> Result<(),
 
     let mut total_percentage = 0;
     for milestone in milestones.iter() {
-        // Reject negative percentages (cast to i32 and check sign)
+        // Reject invalid percentages (handled upstream, but guard here too).
         if milestone.1 > 100 {
-            return Err(NavinError::InvalidConfig);
+            return Err(NavinError::InvalidPaymentMilestones);
         }
         total_percentage += milestone.1;
     }
@@ -971,6 +971,12 @@ impl NavinShipment {
     pub fn initialize(env: Env, admin: Address, token_contract: Address) -> Result<(), NavinError> {
         if storage::is_initialized(&env) {
             return Err(NavinError::AlreadyInitialized);
+        }
+
+        // Reject obviously invalid token addresses: the token contract must not be
+        // the admin account or the shipment contract itself.
+        if token_contract == admin || token_contract == env.current_contract_address() {
+            return Err(NavinError::InvalidTokenAddress);
         }
 
         storage::set_admin(&env, &admin);

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -11585,3 +11585,261 @@ fn test_get_admin_unaffected_by_additional_multisig_admins() {
         "get_admin must not change after init_multisig"
     );
 }
+
+// ── Issue #581 – InvalidPaymentMilestones (code 59) ─────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #59)")]
+fn test_create_shipment_zero_percentage_milestone_rejected() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    // A zero percentage is an invalid milestone weight.
+    milestones.push_back((Symbol::new(&env, "pickup"), 0_u32));
+    milestones.push_back((Symbol::new(&env, "delivery"), 100_u32));
+
+    client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #59)")]
+fn test_create_shipment_over_100_percentage_milestone_rejected() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    // 150 % is out of bounds for a single milestone weight.
+    milestones.push_back((Symbol::new(&env, "pickup"), 150_u32));
+
+    client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+}
+
+#[test]
+fn test_create_shipment_valid_milestones_accepted() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[3u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "pickup"), 50_u32));
+    milestones.push_back((Symbol::new(&env, "delivery"), 50_u32));
+
+    let id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+    assert!(id > 0);
+}
+
+// ── Issue #582 – DuplicatePaymentMilestone (code 60) ────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #60)")]
+fn test_create_shipment_duplicate_milestone_names_rejected() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[4u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "pickup"), 50_u32));
+    milestones.push_back((Symbol::new(&env, "pickup"), 50_u32)); // duplicate
+
+    client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+}
+
+#[test]
+fn test_create_shipment_unique_milestone_names_accepted() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[5u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "pickup"), 40_u32));
+    milestones.push_back((Symbol::new(&env, "transit"), 30_u32));
+    milestones.push_back((Symbol::new(&env, "delivery"), 30_u32));
+
+    let id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+    assert!(id > 0);
+}
+
+// ── Issue #583 – InvalidTokenAddress (code 61) ──────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #61)")]
+fn test_initialize_with_admin_as_token_address_rejected() {
+    let (env, client, admin, _) = setup_shipment_env();
+    // Passing the admin's own address as the token contract is invalid.
+    client.initialize(&admin, &admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #61)")]
+fn test_initialize_with_contract_address_as_token_rejected() {
+    let (env, client, admin, _) = setup_shipment_env();
+    // Passing the shipment contract's own address as the token is invalid.
+    let contract_addr = client.address.clone();
+    client.initialize(&admin, &contract_addr);
+}
+
+#[test]
+fn test_initialize_with_valid_token_address_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    // A real distinct token contract should be accepted.
+    client.initialize(&admin, &token_contract);
+    assert_eq!(client.get_admin(), admin);
+}
+
+// ── Issue #584 – InvalidPaymentMilestoneName (code 62) ──────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #62)")]
+fn test_create_shipment_empty_milestone_name_rejected() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[6u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    // An empty symbol name is an invalid milestone checkpoint name.
+    milestones.push_back((Symbol::new(&env, ""), 100_u32));
+
+    client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #62)")]
+fn test_create_shipment_too_long_milestone_name_rejected() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[7u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    // A 13-character name exceeds the Stellar Symbol 12-char maximum.
+    milestones.push_back((Symbol::new(&env, "toolongname_x"), 100_u32));
+
+    client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+}
+
+#[test]
+fn test_create_shipment_valid_milestone_name_accepted() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[8u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "warehouse"), 100_u32));
+
+    let id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &milestones,
+        &deadline,
+    );
+    assert!(id > 0);
+}

--- a/contracts/shipment/src/test_milestone_payout_order.rs
+++ b/contracts/shipment/src/test_milestone_payout_order.rs
@@ -347,5 +347,5 @@ fn test_validation_rejects_zero_percentage_milestone() {
         &deadline,
     );
 
-    assert_eq!(result, Err(Ok(crate::errors::NavinError::InvalidConfig)));
+    assert_eq!(result, Err(Ok(crate::errors::NavinError::InvalidPaymentMilestones)));
 }

--- a/contracts/shipment/src/validation.rs
+++ b/contracts/shipment/src/validation.rs
@@ -122,11 +122,11 @@ pub fn validate_milestone_symbols(
 ) -> Result<(), NavinError> {
     // Check each milestone symbol for validity and percentage bounds
     for milestone in milestones.iter() {
-        validate_symbol(env, &milestone.0)?;
-        // Reject zero or out-of-bounds percentages (negative values cannot appear
-        // in u32, but values > 100 are equally invalid as percentage weights).
+        // Reject invalid milestone name format with a dedicated error code.
+        validate_symbol(env, &milestone.0).map_err(|_| NavinError::InvalidPaymentMilestoneName)?;
+        // Reject zero or out-of-bounds percentages with a dedicated error code.
         if milestone.1 == 0 || milestone.1 > 100 {
-            return Err(NavinError::InvalidConfig);
+            return Err(NavinError::InvalidPaymentMilestones);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #581, Closes #582, Closes #583, Closes #584

Adds comprehensive tests for four error variant issues and fixes the underlying validation functions to return the correct dedicated error codes.

## Changes

### Test additions (`test.rs`)

**#581 – `InvalidPaymentMilestones` (code 59)**
- `test_create_shipment_zero_percentage_milestone_rejected` – zero weight rejected
- `test_create_shipment_over_100_percentage_milestone_rejected` – over-100% weight rejected
- `test_create_shipment_valid_milestones_accepted` – valid config passes

**#582 – `DuplicatePaymentMilestone` (code 60)**
- `test_create_shipment_duplicate_milestone_names_rejected` – duplicate names rejected
- `test_create_shipment_unique_milestone_names_accepted` – unique names pass

**#583 – `InvalidTokenAddress` (code 61)**
- `test_initialize_with_admin_as_token_address_rejected` – admin address as token rejected
- `test_initialize_with_contract_address_as_token_rejected` – self-referential token rejected
- `test_initialize_with_valid_token_address_succeeds` – valid token address passes

**#584 – `InvalidPaymentMilestoneName` (code 62)**
- `test_create_shipment_empty_milestone_name_rejected` – empty name rejected
- `test_create_shipment_too_long_milestone_name_rejected` – >12-char name rejected
- `test_create_shipment_valid_milestone_name_accepted` – valid name passes

### Bug fixes

- `validation.rs` – `validate_milestone_symbols` now returns `InvalidPaymentMilestoneName` for bad symbol format (was `InvalidConfig`) and `InvalidPaymentMilestones` for bad percentage (was `InvalidConfig`)
- `lib.rs` – `validate_milestones` returns `InvalidPaymentMilestones` (was `InvalidConfig`); `initialize` now guards against admin or self-referential token addresses (`InvalidTokenAddress`)
- `test_milestone_payout_order.rs` – updated assertion to match the corrected error code

## What was tested

All 11 new tests are scoped to the four error variants. CI will run the full test suite on this PR.