### PR TITLE
test(contract): add error-variant test suites for MilestoneSumInvalid, InvalidShipmentInput, BatchTooLarge, ReentrancyDetected

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -108,6 +108,13 @@ mod test_verification;
 mod test_whitelist_multicompany;
 #[cfg(test)]
 mod test_zero_amount_escrow;
+// Error-variant test suites (issues #613–#616)
+#[cfg(test)]
+mod test_milestone_sum_invalid;
+#[cfg(test)]
+mod test_invalid_shipment_input;
+#[cfg(test)]
+mod test_batch_too_large;
 
 // ── Fuzz / property-based test harnesses ─────────────────────────────────────
 #[cfg(test)]

--- a/contracts/shipment/src/test_batch_too_large.rs
+++ b/contracts/shipment/src/test_batch_too_large.rs
@@ -1,0 +1,175 @@
+/// Tests for NavinError::BatchTooLarge (error code 16) — issue #615
+///
+/// Covers:
+///   - create_shipments_batch exceeding the configured batch limit → BatchTooLarge
+///   - create_shipments_batch within the limit → success
+///   - get_shipments_batch exceeding the hard 50-item query cap → BatchTooLarge
+///   - get_shipments_batch within the cap → success
+extern crate std;
+
+use crate::{test::setup_shipment_env, NavinError, ShipmentInput};
+use soroban_sdk::{testutils::Address as _, Address, BytesN};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn make_shipment_input(env: &soroban_sdk::Env, marker: u8) -> ShipmentInput {
+    ShipmentInput {
+        receiver: Address::generate(env),
+        carrier: Address::generate(env),
+        data_hash: BytesN::from_array(env, &[marker; 32]),
+        payment_milestones: soroban_sdk::Vec::new(env),
+        deadline: env.ledger().timestamp() + 7200,
+    }
+}
+
+fn push_shipments(env: &soroban_sdk::Env, n: usize) -> soroban_sdk::Vec<ShipmentInput> {
+    let mut v = soroban_sdk::Vec::new(env);
+    for i in 0..n {
+        v.push_back(make_shipment_input(env, (i % 255) as u8 + 1));
+    }
+    v
+}
+
+// ── create_shipments_batch — over limit ──────────────────────────────────────
+
+#[test]
+fn test_create_batch_11_returns_batch_too_large() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipments = push_shipments(&env, 11); // default limit is 10
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::BatchTooLarge)),
+        "11 shipments must return BatchTooLarge"
+    );
+}
+
+#[test]
+fn test_create_batch_20_returns_batch_too_large() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipments = push_shipments(&env, 20);
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::BatchTooLarge)),
+        "20 shipments must return BatchTooLarge"
+    );
+}
+
+// ── create_shipments_batch — within limit ────────────────────────────────────
+
+#[test]
+fn test_create_batch_1_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipments = push_shipments(&env, 1);
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert!(result.is_ok(), "single-item batch must succeed");
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_create_batch_at_limit_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // Default limit is 10; batch of exactly 10 must succeed
+    let shipments = push_shipments(&env, 10);
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert!(result.is_ok(), "batch of exactly 10 must succeed");
+    assert_eq!(result.unwrap().len(), 10);
+}
+
+#[test]
+fn test_create_batch_5_succeeds_and_assigns_sequential_ids() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipments = push_shipments(&env, 5);
+    let ids = client.create_shipments_batch(&company, &shipments);
+    assert_eq!(ids.len(), 5, "batch of 5 must return 5 ids");
+    for (i, id) in ids.iter().enumerate() {
+        assert_eq!(id, (i + 1) as u64, "ids must be sequential from 1");
+    }
+}
+
+// ── get_shipments_batch — over the 50-item query cap ─────────────────────────
+
+#[test]
+fn test_query_batch_51_returns_batch_too_large() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for i in 0..51_u64 {
+        ids.push_back(i + 1);
+    }
+
+    let result = client.try_get_shipments_batch(&ids);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::BatchTooLarge)),
+        "query of 51 ids must return BatchTooLarge"
+    );
+}
+
+#[test]
+fn test_query_batch_50_is_accepted() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for i in 0..50_u64 {
+        ids.push_back(i + 1); // IDs that don't exist will return None in the result
+    }
+
+    // Should not error with BatchTooLarge — all 50 slots return None for missing ids
+    let result = client.try_get_shipments_batch(&ids);
+    assert!(
+        result.is_ok(),
+        "query of exactly 50 ids must not return BatchTooLarge"
+    );
+}
+
+// ── error code assertion ──────────────────────────────────────────────────────
+
+#[test]
+fn test_error_code_is_16() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipments = push_shipments(&env, 11);
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::BatchTooLarge)),
+        "BatchTooLarge discriminant must be 16"
+    );
+    assert_eq!(NavinError::BatchTooLarge as u32, 16);
+}

--- a/contracts/shipment/src/test_invalid_shipment_input.rs
+++ b/contracts/shipment/src/test_invalid_shipment_input.rs
@@ -1,0 +1,177 @@
+/// Tests for NavinError::InvalidShipmentInput (error code 17) — issue #614
+///
+/// Validates that create_shipments_batch rejects parameter combinations where
+/// receiver equals carrier, while accepting distinct participant addresses.
+extern crate std;
+
+use crate::{test::setup_shipment_env, NavinError, ShipmentInput};
+use soroban_sdk::{testutils::Address as _, Address, BytesN};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn make_input(
+    env: &soroban_sdk::Env,
+    receiver: &Address,
+    carrier: &Address,
+    marker: u8,
+) -> ShipmentInput {
+    ShipmentInput {
+        receiver: receiver.clone(),
+        carrier: carrier.clone(),
+        data_hash: BytesN::from_array(env, &[marker; 32]),
+        payment_milestones: soroban_sdk::Vec::new(env),
+        deadline: env.ledger().timestamp() + 7200,
+    }
+}
+
+// ── invalid inputs ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_batch_receiver_equals_carrier_returns_error() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shared = Address::generate(&env);
+    let mut shipments = soroban_sdk::Vec::new(&env);
+    shipments.push_back(make_input(&env, &shared, &shared, 1));
+
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidShipmentInput)),
+        "receiver == carrier must return InvalidShipmentInput"
+    );
+}
+
+#[test]
+fn test_batch_second_entry_invalid_first_valid() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let r1 = Address::generate(&env);
+    let c1 = Address::generate(&env);
+    let shared = Address::generate(&env);
+
+    let mut shipments = soroban_sdk::Vec::new(&env);
+    shipments.push_back(make_input(&env, &r1, &c1, 10)); // valid
+    shipments.push_back(make_input(&env, &shared, &shared, 20)); // invalid — receiver == carrier
+
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidShipmentInput)),
+        "invalid entry in batch must propagate error even when preceding entries are valid"
+    );
+}
+
+#[test]
+fn test_batch_all_entries_invalid() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+
+    let mut shipments = soroban_sdk::Vec::new(&env);
+    shipments.push_back(make_input(&env, &s1, &s1, 30)); // receiver == carrier
+    shipments.push_back(make_input(&env, &s2, &s2, 40)); // receiver == carrier
+
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidShipmentInput)),
+        "all-invalid batch must return InvalidShipmentInput"
+    );
+}
+
+// ── valid inputs ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_batch_distinct_participants_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+
+    let mut shipments = soroban_sdk::Vec::new(&env);
+    shipments.push_back(make_input(&env, &receiver, &carrier, 50));
+
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert!(
+        result.is_ok(),
+        "distinct receiver and carrier must create shipment successfully"
+    );
+}
+
+#[test]
+fn test_batch_multiple_valid_entries_all_succeed() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let mut shipments = soroban_sdk::Vec::new(&env);
+    for i in 0u8..3 {
+        let receiver = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        shipments.push_back(make_input(&env, &receiver, &carrier, i + 60));
+    }
+
+    let ids = client.try_create_shipments_batch(&company, &shipments);
+    assert!(ids.is_ok(), "all-valid batch must succeed");
+    assert_eq!(ids.unwrap().len(), 3);
+}
+
+#[test]
+fn test_create_single_shipment_distinct_participants_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[0xFFu8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash,
+        &soroban_sdk::Vec::new(&env), &deadline,
+    );
+    assert!(result.is_ok(), "single shipment with valid participants must succeed");
+}
+
+#[test]
+fn test_error_code_is_17() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shared = Address::generate(&env);
+    let mut shipments = soroban_sdk::Vec::new(&env);
+    shipments.push_back(make_input(&env, &shared, &shared, 99));
+
+    let result = client.try_create_shipments_batch(&company, &shipments);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::InvalidShipmentInput)),
+        "InvalidShipmentInput discriminant must be 17"
+    );
+    assert_eq!(NavinError::InvalidShipmentInput as u32, 17);
+}

--- a/contracts/shipment/src/test_milestone_sum_invalid.rs
+++ b/contracts/shipment/src/test_milestone_sum_invalid.rs
@@ -1,0 +1,196 @@
+/// Tests for NavinError::MilestoneSumInvalid (error code 18) — issue #613
+///
+/// Verifies that milestone percentage sum validation is enforced on shipment
+/// creation: a sum != 100 must return MilestoneSumInvalid, while a sum of
+/// exactly 100 must succeed.
+extern crate std;
+
+use crate::{test::setup_shipment_env, NavinError};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Symbol};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn base_shipment_parts(
+    env: &soroban_sdk::Env,
+) -> (Address, Address, Address, BytesN<32>, u64) {
+    let company = Address::generate(env);
+    let receiver = Address::generate(env);
+    let carrier = Address::generate(env);
+    let data_hash = BytesN::from_array(env, &[0xABu8; 32]);
+    let deadline = env.ledger().timestamp() + 7200;
+    (company, receiver, carrier, data_hash, deadline)
+}
+
+// ── invalid sums ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_milestone_sum_over_100_returns_error() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // 60 + 60 = 120 — over 100
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "stage1"), 60u32));
+    milestones.push_back((Symbol::new(&env, "stage2"), 60u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::MilestoneSumInvalid)),
+        "sum 120 must return MilestoneSumInvalid"
+    );
+}
+
+#[test]
+fn test_milestone_sum_under_100_returns_error() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // 30 + 30 = 60 — under 100
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "alpha"), 30u32));
+    milestones.push_back((Symbol::new(&env, "beta"), 30u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::MilestoneSumInvalid)),
+        "sum 60 must return MilestoneSumInvalid"
+    );
+}
+
+#[test]
+fn test_milestone_single_entry_not_100_returns_error() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // Single milestone at 99 — not 100
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "only"), 99u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::MilestoneSumInvalid)),
+        "single milestone at 99% must return MilestoneSumInvalid"
+    );
+}
+
+#[test]
+fn test_milestone_zero_sum_returns_error() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // Two milestones both at 0 — sum = 0
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "zero1"), 0u32));
+    milestones.push_back((Symbol::new(&env, "zero2"), 0u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::MilestoneSumInvalid)),
+        "sum 0 must return MilestoneSumInvalid"
+    );
+}
+
+// ── valid sums ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_milestone_sum_exactly_100_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // 25 + 75 = 100 — valid
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "first"), 25u32));
+    milestones.push_back((Symbol::new(&env, "final"), 75u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert!(result.is_ok(), "sum 100 must create shipment successfully");
+}
+
+#[test]
+fn test_milestone_three_parts_summing_100_succeeds() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // 20 + 30 + 50 = 100
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "part1"), 20u32));
+    milestones.push_back((Symbol::new(&env, "part2"), 30u32));
+    milestones.push_back((Symbol::new(&env, "part3"), 50u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert!(result.is_ok(), "three milestones summing to 100 must succeed");
+}
+
+#[test]
+fn test_no_milestones_creates_shipment_without_error() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    // Empty milestone list — no sum constraint applies
+    let milestones = soroban_sdk::Vec::new(&env);
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert!(result.is_ok(), "empty milestones must create shipment without error");
+}
+
+#[test]
+fn test_error_code_is_18() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let (company, receiver, carrier, data_hash, deadline) = base_shipment_parts(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back((Symbol::new(&env, "m1"), 50u32));
+    milestones.push_back((Symbol::new(&env, "m2"), 60u32));
+
+    let result = client.try_create_shipment(
+        &company, &receiver, &carrier, &data_hash, &milestones, &deadline,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::MilestoneSumInvalid)),
+        "MilestoneSumInvalid discriminant must be 18"
+    );
+    assert_eq!(NavinError::MilestoneSumInvalid as u32, 18);
+}

--- a/contracts/shipment/src/test_reentrancy_guard.rs
+++ b/contracts/shipment/src/test_reentrancy_guard.rs
@@ -229,3 +229,93 @@ fn test_multiple_guard_operations_lock_stays_blocked() {
         "deposit on delivered should still fail for status reason"
     );
 }
+
+// ── Additional tests for issue #616 ──────────────────────────────────────────
+
+#[test]
+fn test_reentrancy_detected_error_code_is_15() {
+    let (env, client, _admin, company, _receiver, _carrier, shipment_id) = setup_single_shipment();
+
+    env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyLock, &true);
+    });
+
+    let result = client.try_deposit_escrow(&company, &shipment_id, &500);
+    assert_eq!(
+        result,
+        Err(Ok(NavinError::ReentrancyDetected)),
+        "ReentrancyDetected discriminant must be 15"
+    );
+    assert_eq!(NavinError::ReentrancyDetected as u32, 15);
+}
+
+#[test]
+fn test_normal_deposit_succeeds_without_lock() {
+    let (env, client, _admin, company, _receiver, _carrier, shipment_id) = setup_single_shipment();
+
+    // Confirm lock is NOT held before the call
+    env.as_contract(&client.address, || {
+        let locked = env
+            .storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::ReentrancyLock)
+            .unwrap_or(false);
+        assert!(!locked, "lock must not be held before a normal operation");
+    });
+
+    let result = client.try_deposit_escrow(&company, &shipment_id, &1000);
+    assert!(
+        result.is_ok(),
+        "deposit without reentrancy lock must succeed"
+    );
+}
+
+#[test]
+fn test_normal_refund_succeeds_without_lock() {
+    let (env, client, _admin, company, _receiver, _carrier, shipment_id) = setup_single_shipment();
+
+    client.deposit_escrow(&company, &shipment_id, &500);
+
+    // Ensure lock is clear
+    env.as_contract(&client.address, || {
+        let locked = env
+            .storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::ReentrancyLock)
+            .unwrap_or(false);
+        assert!(!locked, "lock must be released after successful deposit");
+    });
+
+    let result = client.try_refund_escrow(&company, &shipment_id);
+    assert!(
+        result.is_ok(),
+        "refund without reentrancy lock must succeed"
+    );
+}
+
+#[test]
+fn test_lock_preheld_blocks_all_three_escrow_ops() {
+    let (env, client, _admin, company, receiver, _carrier, shipment_id) = setup_single_shipment();
+
+    client.deposit_escrow(&company, &shipment_id, &1000);
+
+    // Pre-hold the lock to simulate mid-execution state
+    env.as_contract(&client.address, || {
+        let mut s = crate::storage::get_shipment(&env, shipment_id).unwrap();
+        s.status = crate::ShipmentStatus::Delivered;
+        crate::storage::set_shipment(&env, &s);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyLock, &true);
+    });
+
+    let dep = client.try_deposit_escrow(&company, &shipment_id, &100);
+    let rel = client.try_release_escrow(&receiver, &shipment_id);
+    let ref_ = client.try_refund_escrow(&company, &shipment_id);
+
+    assert_eq!(dep, Err(Ok(NavinError::ReentrancyDetected)), "deposit must be blocked");
+    assert_eq!(rel, Err(Ok(NavinError::ReentrancyDetected)), "release must be blocked");
+    assert_eq!(ref_, Err(Ok(NavinError::ReentrancyDetected)), "refund must be blocked");
+}


### PR DESCRIPTION
## Summary

Four dedicated test suites for the error variants assigned in issues #613–#616. All tests use the `try_*` pattern (returning `Err(Ok(NavinError::…))`) rather than `#[should_panic]`, providing precise error-code assertions. Three new test modules are wired into `lib.rs`; the reentrancy suite extends the existing file.

---

### #613 — `test_milestone_sum_invalid.rs` (`MilestoneSumInvalid`, code 18)

| Test | Input | Expected |
|------|-------|---------|
| `test_milestone_sum_over_100_returns_error` | 60 + 60 = 120 | `Err(MilestoneSumInvalid)` |
| `test_milestone_sum_under_100_returns_error` | 30 + 30 = 60 | `Err(MilestoneSumInvalid)` |
| `test_milestone_single_entry_not_100_returns_error` | single at 99 | `Err(MilestoneSumInvalid)` |
| `test_milestone_zero_sum_returns_error` | 0 + 0 = 0 | `Err(MilestoneSumInvalid)` |
| `test_milestone_sum_exactly_100_succeeds` | 25 + 75 = 100 | `Ok` |
| `test_milestone_three_parts_summing_100_succeeds` | 20 + 30 + 50 = 100 | `Ok` |
| `test_no_milestones_creates_shipment_without_error` | empty list | `Ok` |
| `test_error_code_is_18` | asserts discriminant | `NavinError::MilestoneSumInvalid as u32 == 18` |

---

### #614 — `test_invalid_shipment_input.rs` (`InvalidShipmentInput`, code 17)

| Test | Scenario | Expected |
|------|----------|---------|
| `test_batch_receiver_equals_carrier_returns_error` | receiver == carrier | `Err(InvalidShipmentInput)` |
| `test_batch_second_entry_invalid_first_valid` | invalid entry in mixed batch | `Err(InvalidShipmentInput)` |
| `test_batch_all_entries_invalid` | all receiver == carrier | `Err(InvalidShipmentInput)` |
| `test_batch_distinct_participants_succeeds` | distinct addresses | `Ok` |
| `test_batch_multiple_valid_entries_all_succeed` | 3 valid entries | `Ok`, len 3 |
| `test_create_single_shipment_distinct_participants_succeeds` | single valid call | `Ok` |
| `test_error_code_is_17` | asserts discriminant | `NavinError::InvalidShipmentInput as u32 == 17` |

---

### #615 — `test_batch_too_large.rs` (`BatchTooLarge`, code 16)

| Test | Size | Expected |
|------|------|---------|
| `test_create_batch_11_returns_batch_too_large` | 11 (over limit of 10) | `Err(BatchTooLarge)` |
| `test_create_batch_20_returns_batch_too_large` | 20 | `Err(BatchTooLarge)` |
| `test_create_batch_1_succeeds` | 1 | `Ok`, len 1 |
| `test_create_batch_at_limit_succeeds` | 10 (at limit) | `Ok`, len 10 |
| `test_create_batch_5_succeeds_and_assigns_sequential_ids` | 5 | `Ok`, ids 1–5 |
| `test_query_batch_51_returns_batch_too_large` | 51 query ids | `Err(BatchTooLarge)` |
| `test_query_batch_50_is_accepted` | 50 query ids | `Ok` |
| `test_error_code_is_16` | asserts discriminant | `NavinError::BatchTooLarge as u32 == 16` |

---

### #616 — Extended `test_reentrancy_guard.rs` (`ReentrancyDetected`, code 15)

Four additional tests appended to the existing suite:

- `test_reentrancy_detected_error_code_is_15` — confirms discriminant == 15
- `test_normal_deposit_succeeds_without_lock` — no false positives on clean state
- `test_normal_refund_succeeds_without_lock` — lock is released after successful deposit
- `test_lock_preheld_blocks_all_three_escrow_ops` — deposit, release, and refund are each blocked when the lock is pre-held

Closes #613
Closes #614
Closes #615
Closes #616