### PR TITLE
feat: expose get_circuit_breaker_status, is_company_suspended, get_platform_fee_config as public queries

### DIFF
--- a/contracts/shipment/src/circuit_breaker.rs
+++ b/contracts/shipment/src/circuit_breaker.rs
@@ -319,7 +319,6 @@ pub fn manual_reset(env: &Env, admin: &Address) -> Result<(), NavinError> {
 ///
 /// # Returns
 /// * `(state, failure_count, recovery_time_remaining)` tuple
-#[allow(dead_code)]
 pub fn get_breaker_status(
     env: &Env,
     config: &CircuitBreakerConfig,

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -129,6 +129,7 @@ mod fuzz_wallet_auth_integration;
 #[cfg(test)]
 mod preservation_property_tests;
 
+pub use circuit_breaker::{CircuitBreakerConfig, CircuitBreakerState};
 pub use config::*;
 pub use consistency::*;
 pub use diagnostics::*;
@@ -1698,6 +1699,27 @@ impl NavinShipment {
     pub fn is_carrier_suspended(env: Env, carrier: Address) -> Result<bool, NavinError> {
         require_initialized(&env)?;
         Ok(storage::is_carrier_suspended(&env, &carrier))
+    }
+
+    /// Return whether a company is currently suspended.
+    ///
+    /// Mirrors `is_carrier_suspended` for the company side of the same
+    /// suspension model. A suspended company cannot create shipments or
+    /// deposit escrow.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    /// * `company` - The company address to query.
+    ///
+    /// # Returns
+    /// * `Ok(true)` if the company has an active suspension.
+    /// * `Ok(false)` if the company is active (or has never been added).
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    pub fn is_company_suspended(env: Env, company: Address) -> Result<bool, NavinError> {
+        require_initialized(&env)?;
+        Ok(storage::is_company_suspended(&env, &company))
     }
 
     /// Revoke a previously assigned role from an address.
@@ -5411,6 +5433,26 @@ impl NavinShipment {
         Ok(())
     }
 
+    /// Return the active platform fee configuration.
+    ///
+    /// Returns the `FeeConfig` last written by `set_platform_fee`, containing
+    /// the fee rate in basis points and the treasury address that collects fees.
+    /// Returns `None` if `set_platform_fee` has never been called.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    ///
+    /// # Returns
+    /// * `Ok(Some(FeeConfig))` if a fee config has been set.
+    /// * `Ok(None)` if no fee config has been set yet.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    pub fn get_platform_fee_config(env: Env) -> Result<Option<FeeConfig>, NavinError> {
+        require_initialized(&env)?;
+        Ok(storage::get_fee_config(&env))
+    }
+
     /// Add a new carrier to the contract.
     ///
     /// # Arguments
@@ -5756,6 +5798,32 @@ impl NavinShipment {
     pub fn reset_circuit_breaker(env: Env, admin: Address) -> Result<(), NavinError> {
         require_initialized(&env)?;
         circuit_breaker::manual_reset(&env, &admin)
+    }
+
+    /// Query the current circuit breaker status without modifying state.
+    ///
+    /// Returns the breaker state, accumulated failure count, and the number of
+    /// seconds remaining before the breaker transitions from Open to HalfOpen
+    /// (0 when the breaker is Closed or already in HalfOpen).
+    ///
+    /// Operators should call this before deciding whether to invoke
+    /// `reset_circuit_breaker`, to confirm the breaker is actually open and
+    /// how long until automatic recovery would occur.
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    ///
+    /// # Returns
+    /// * `(CircuitBreakerState, u32, u64)` — `(state, failure_count, recovery_time_remaining_secs)`.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    pub fn get_circuit_breaker_status(
+        env: Env,
+    ) -> Result<(CircuitBreakerState, u32, u64), NavinError> {
+        require_initialized(&env)?;
+        let config = circuit_breaker::CircuitBreakerConfig::default();
+        Ok(circuit_breaker::get_breaker_status(&env, &config))
     }
 
     /// Scan all tracked shipments and return every consistency violation found.

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -12883,3 +12883,147 @@ fn test_create_shipment_valid_milestone_name_accepted() {
     );
     assert!(id > 0);
 }
+
+// ── get_circuit_breaker_status tests (issue #640) ─────────────────────────────
+
+#[test]
+fn test_get_circuit_breaker_status_closed_by_default() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let (state, failure_count, recovery_remaining) = client.get_circuit_breaker_status();
+    assert_eq!(state, crate::CircuitBreakerState::Closed);
+    assert_eq!(failure_count, 0);
+    assert_eq!(recovery_remaining, 0);
+}
+
+#[test]
+fn test_get_circuit_breaker_status_open() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    // Inject Open state directly — Soroban rolls back storage on error so we
+    // cannot accumulate real failures through contract calls.
+    let opened_at = env.ledger().timestamp();
+    env.as_contract(&client.address, || {
+        let tracker = crate::circuit_breaker::CircuitBreakerTracker {
+            state: crate::circuit_breaker::CircuitBreakerState::Open,
+            failure_count: 5,
+            opened_at,
+            half_open_requests: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&crate::types::DataKey::CircuitBreakerState, &tracker);
+    });
+
+    let (state, failure_count, recovery_remaining) = client.get_circuit_breaker_status();
+    assert_eq!(state, crate::CircuitBreakerState::Open);
+    assert_eq!(failure_count, 5);
+    // Default recovery_timeout is 300 s; we just opened it so ~300 s remain.
+    assert!(recovery_remaining > 0 && recovery_remaining <= 300);
+}
+
+#[test]
+fn test_get_circuit_breaker_status_half_open() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    // Inject HalfOpen state.
+    env.as_contract(&client.address, || {
+        let tracker = crate::circuit_breaker::CircuitBreakerTracker {
+            state: crate::circuit_breaker::CircuitBreakerState::HalfOpen,
+            failure_count: 5,
+            opened_at: env.ledger().timestamp(),
+            half_open_requests: 1,
+        };
+        env.storage()
+            .persistent()
+            .set(&crate::types::DataKey::CircuitBreakerState, &tracker);
+    });
+
+    let (state, failure_count, recovery_remaining) = client.get_circuit_breaker_status();
+    assert_eq!(state, crate::CircuitBreakerState::HalfOpen);
+    assert_eq!(failure_count, 5);
+    // HalfOpen means recovery window has already passed — no time remaining.
+    assert_eq!(recovery_remaining, 0);
+}
+
+// ── is_company_suspended tests (issue #642) ───────────────────────────────────
+
+#[test]
+fn test_is_company_suspended_active_by_default() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    assert!(!client.is_company_suspended(&company));
+}
+
+#[test]
+fn test_is_company_suspended_returns_true_when_suspended() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    client.suspend_company(&admin, &company);
+    assert!(client.is_company_suspended(&company));
+}
+
+#[test]
+fn test_is_company_suspended_returns_false_after_reactivation() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    client.suspend_company(&admin, &company);
+    assert!(client.is_company_suspended(&company));
+
+    client.reactivate_company(&admin, &company);
+    assert!(!client.is_company_suspended(&company));
+}
+
+// ── get_platform_fee_config tests (issue #641) ────────────────────────────────
+
+#[test]
+fn test_get_platform_fee_config_none_before_set() {
+    let (_env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+
+    let config = client.get_platform_fee_config();
+    assert!(config.is_none());
+}
+
+#[test]
+fn test_get_platform_fee_config_reflects_set_platform_fee() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let treasury = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.set_platform_fee(&admin, &50_u32, &treasury);
+
+    let config = client.get_platform_fee_config().expect("fee config should be set");
+    assert_eq!(config.fee_bps, 50);
+    assert_eq!(config.treasury, treasury);
+}
+
+#[test]
+fn test_get_platform_fee_config_reflects_updated_value() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let treasury1 = Address::generate(&env);
+    let treasury2 = Address::generate(&env);
+
+    client.initialize(&admin, &token_contract);
+    client.set_platform_fee(&admin, &100_u32, &treasury1);
+    client.set_platform_fee(&admin, &200_u32, &treasury2);
+
+    let config = client.get_platform_fee_config().expect("fee config should be set");
+    assert_eq!(config.fee_bps, 200);
+    assert_eq!(config.treasury, treasury2);
+}


### PR DESCRIPTION
## Summary

Exposes three internal functions as public contract queries, closing the asymmetry between write and read operations for operators and client integrations.

---

### #640 — `get_circuit_breaker_status`

- Added `pub fn get_circuit_breaker_status(env: Env) -> Result<(CircuitBreakerState, u32, u64), NavinError>` wrapping `circuit_breaker::get_breaker_status`
- Removed the now-unnecessary `#[allow(dead_code)]` attribute from `get_breaker_status`
- Re-exported `CircuitBreakerState` and `CircuitBreakerConfig` from the crate root (`pub use circuit_breaker::{...}`) so the return type is accessible to callers
- Returns `(state, failure_count, recovery_time_remaining_secs)`; operators can inspect before deciding whether to call `reset_circuit_breaker`

### #642 — `is_company_suspended`

- Added `pub fn is_company_suspended(env: Env, company: Address) -> Result<bool, NavinError>` mirroring the existing `is_carrier_suspended` pattern exactly
- Placed immediately after `is_carrier_suspended` in `lib.rs` for discoverability

### #641 — `get_platform_fee_config`

- Added `pub fn get_platform_fee_config(env: Env) -> Result<Option<FeeConfig>, NavinError>` returning the `FeeConfig` last written by `set_platform_fee`
- Returns `None` if `set_platform_fee` has never been called
- Placed immediately after `set_platform_fee` in `lib.rs` and documented alongside it

---

## Tests

9 new tests added to `test.rs`:

| Test | Covers |
|---|---|
| `test_get_circuit_breaker_status_closed_by_default` | Closed state (fresh contract) |
| `test_get_circuit_breaker_status_open` | Open state, positive recovery_remaining |
| `test_get_circuit_breaker_status_half_open` | HalfOpen state, zero recovery_remaining |
| `test_is_company_suspended_active_by_default` | Active company returns false |
| `test_is_company_suspended_returns_true_when_suspended` | Suspended company returns true |
| `test_is_company_suspended_returns_false_after_reactivation` | Reactivated company returns false |
| `test_get_platform_fee_config_none_before_set` | Returns None before first set |
| `test_get_platform_fee_config_reflects_set_platform_fee` | Matches the written fee_bps and treasury |
| `test_get_platform_fee_config_reflects_updated_value` | Always reflects the latest write |

---

## Files changed

- `contracts/shipment/src/circuit_breaker.rs`
- `contracts/shipment/src/lib.rs`
- `contracts/shipment/src/test.rs`

Closes #640
Closes #641
Closes #642
Closes #643 