### PR TITLE
fix(consistency): cap check_all_consistency + add paginated variant (#648)

### DIFF
--- a/contracts/shipment/src/consistency.rs
+++ b/contracts/shipment/src/consistency.rs
@@ -16,9 +16,19 @@
 //! **Batch (cross-shipment) invariants:**
 //! - `BatchSenderMismatch`: all shipments in a batch must share the same `sender`.
 //! - `BatchTimestampMismatch`: all shipments in a batch must share the same `created_at`.
+//!
+//! ## Scan-safety
+//!
+//! The default `check_all_consistency` is capped at `DEFAULT_CONSISTENCY_SAMPLE_LIMIT`
+//! shipments (matching the strategy used by `diagnostics::run_system_health_check`).
+//! Use `check_all_consistency_range` when a full audit over an arbitrary window is needed.
 
 use crate::{storage, types::ShipmentStatus};
 use soroban_sdk::{contracttype, Address, Env, Vec};
+
+/// Default sample cap for consistency scans (budget safety on large sets,
+/// matching `diagnostics::DEFAULT_HEALTH_SAMPLE_LIMIT`).
+pub const DEFAULT_CONSISTENCY_SAMPLE_LIMIT: u64 = 100;
 
 /// A detected violation of a consistency invariant.
 ///
@@ -164,18 +174,29 @@ pub fn check_batch_consistency(env: &Env, ids: &Vec<u64>) -> Vec<ConsistencyViol
 }
 
 /// Reconcile the global per-status counters against the actual count of
-/// shipments in each status. Returns `StatusCountMismatch` if any counter
-/// has drifted.
+/// shipments in each status, scanning only the window `[start_id, end_id]`.
 ///
-/// This is an O(n) scan and is intended only for admin/operator use.
+/// Returns `StatusCountMismatch` if any counter has drifted within the window.
+/// Because only a subset is scanned the comparison is approximate — use this
+/// when you need a bounded-cost check rather than a full audit.
 ///
 /// # Arguments
 /// * `env` - Execution environment.
-pub fn check_status_count_consistency(env: &Env) -> Vec<ConsistencyViolation> {
+/// * `start_id` - First shipment ID to include (1-indexed, inclusive).
+/// * `end_id` - Last shipment ID to include (inclusive); clamped to the total count.
+fn check_status_count_consistency_range(
+    env: &Env,
+    start_id: u64,
+    end_id: u64,
+) -> Vec<ConsistencyViolation> {
     let mut violations: Vec<ConsistencyViolation> = Vec::new(env);
     let total = storage::get_shipment_count(env);
 
-    // Scan all shipments and count actual statuses.
+    if start_id == 0 || start_id > total {
+        return violations;
+    }
+    let end = end_id.min(total);
+
     use crate::types::ShipmentStatus::*;
     let mut actual = [
         (Created, 0u64),
@@ -188,7 +209,7 @@ pub fn check_status_count_consistency(env: &Env) -> Vec<ConsistencyViolation> {
         (PartiallyRefunded, 0),
     ];
 
-    for id in 1..=total {
+    for id in start_id..=end {
         if let Some(shipment) = storage::get_shipment(env, id) {
             for (status, count) in actual.iter_mut() {
                 if shipment.status == *status {
@@ -198,42 +219,94 @@ pub fn check_status_count_consistency(env: &Env) -> Vec<ConsistencyViolation> {
         }
     }
 
-    // Compare with stored counters.
-    for (status, actual_count) in &actual {
-        let stored = storage::get_status_count(env, status);
-        if stored != *actual_count {
-            violations.push_back(ConsistencyViolation::StatusCountMismatch);
-            break;
+    // Only flag a mismatch when the window covers the full shipment set; a
+    // partial window cannot reliably confirm global counter accuracy.
+    let is_full_scan = start_id == 1 && end >= total;
+    if is_full_scan {
+        for (status, actual_count) in &actual {
+            let stored = storage::get_status_count(env, status);
+            if stored != *actual_count {
+                violations.push_back(ConsistencyViolation::StatusCountMismatch);
+                break;
+            }
         }
     }
 
     violations
 }
 
-/// Scan all shipments (IDs 1 through the global counter) and return every
-/// consistency violation found.
+/// Reconcile the global per-status counters against the actual count of
+/// shipments in each status. Returns `StatusCountMismatch` if any counter
+/// has drifted.
 ///
-/// This is an O(n) scan and is intended only for admin/operator use, not for
-/// hot-path contract logic.
+/// This performs a full O(n) scan and is intended only for admin/operator use.
+/// For budget-safe checks prefer `check_all_consistency` (capped) or
+/// `check_all_consistency_range` (paginated).
 ///
 /// # Arguments
 /// * `env` - Execution environment.
-pub fn check_all_consistency(env: &Env) -> Vec<ConsistencyViolation> {
+pub fn check_status_count_consistency(env: &Env) -> Vec<ConsistencyViolation> {
+    let total = storage::get_shipment_count(env);
+    check_status_count_consistency_range(env, 1, total)
+}
+
+/// Scan shipments in the window `[start_id, start_id + limit - 1]` and return
+/// every consistency violation found in that page.
+///
+/// This is the paginated variant intended for full-set audits: callers step
+/// through the entire shipment space by incrementing `start_id` by `limit`
+/// between calls.
+///
+/// Per-status counter drift (`StatusCountMismatch`) is only reported when the
+/// requested window covers the complete shipment set.
+///
+/// # Arguments
+/// * `env` - Execution environment.
+/// * `start_id` - First shipment ID to scan (1-indexed).
+/// * `limit` - Number of shipments to inspect; clamped to remaining IDs.
+pub fn check_all_consistency_range(
+    env: &Env,
+    start_id: u64,
+    limit: u64,
+) -> Vec<ConsistencyViolation> {
     let total = storage::get_shipment_count(env);
     let mut violations: Vec<ConsistencyViolation> = Vec::new(env);
 
-    for id in 1..=total {
+    if start_id == 0 || start_id > total || limit == 0 {
+        return violations;
+    }
+
+    let end_id = start_id
+        .saturating_add(limit)
+        .saturating_sub(1)
+        .min(total);
+
+    for id in start_id..=end_id {
         let per_ship = check_shipment_invariants(env, id);
         for v in per_ship.iter() {
             violations.push_back(v);
         }
     }
 
-    // Global invariant: per-status counters must match actual counts.
-    let counter_violations = check_status_count_consistency(env);
+    // Append status-counter drift check (only meaningful on a full scan).
+    let counter_violations = check_status_count_consistency_range(env, start_id, end_id);
     for v in counter_violations.iter() {
         violations.push_back(v);
     }
 
     violations
+}
+
+/// Scan up to `DEFAULT_CONSISTENCY_SAMPLE_LIMIT` shipments (IDs 1 through
+/// the cap) and return every consistency violation found in the sample.
+///
+/// This keeps compute cost within the Soroban budget regardless of total
+/// shipment count, matching the strategy used by
+/// `diagnostics::run_system_health_check`. For full-set audits, use
+/// `check_all_consistency_range` with explicit pagination instead.
+///
+/// # Arguments
+/// * `env` - Execution environment.
+pub fn check_all_consistency(env: &Env) -> Vec<ConsistencyViolation> {
+    check_all_consistency_range(env, 1, DEFAULT_CONSISTENCY_SAMPLE_LIMIT)
 }

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -5960,17 +5960,21 @@ impl NavinShipment {
         circuit_breaker::manual_reset(&env, &admin)
     }
 
-    /// Scan all tracked shipments and return every consistency violation found.
+    /// Scan a capped sample of tracked shipments and return every consistency
+    /// violation found.
     ///
-    /// Checks per-shipment invariants across the full ledger:
+    /// Checks per-shipment invariants across the first
+    /// `DEFAULT_CONSISTENCY_SAMPLE_LIMIT` shipments:
     /// - Escrow amounts match storage
     /// - Finalized flag is only set on terminal shipments with zero escrow
     /// - Paid milestones are a subset of the payment schedule
     /// - Timestamps are non-decreasing
     /// - Deadlines are strictly after creation time
     ///
-    /// Intended for periodic admin audits; not safe to call on hot paths
-    /// due to the O(n) scan over all shipments.
+    /// The scan is capped at `DEFAULT_CONSISTENCY_SAMPLE_LIMIT` entries so that
+    /// compute cost stays within budget as the shipment set grows. For a full
+    /// audit over the entire ledger, use `check_consistency_violations_paginated`
+    /// to step through all pages.
     ///
     /// # Arguments
     /// * `env` - Execution environment.
@@ -5978,7 +5982,7 @@ impl NavinShipment {
     ///
     /// # Returns
     /// * `Result<Vec<ConsistencyViolation>, NavinError>` - List of detected violations.
-    ///   An empty vec means all invariants hold.
+    ///   An empty vec means all sampled invariants hold.
     ///
     /// # Errors
     /// * `NavinError::NotInitialized` - If contract is not initialized.
@@ -5991,6 +5995,55 @@ impl NavinShipment {
         admin.require_auth();
         require_admin_or_operator(&env, &admin)?;
         Ok(consistency::check_all_consistency(&env))
+    }
+
+    /// Scan a specific page of shipments and return every consistency violation
+    /// found in that window.
+    ///
+    /// This is the paginated variant for full-set audits. Callers advance
+    /// through the entire shipment space by incrementing `start_id` by `limit`
+    /// on each call until no more results are returned.
+    ///
+    /// Per-status counter drift (`StatusCountMismatch`) is only reported when
+    /// the requested window covers the complete shipment set (i.e. the final
+    /// page that reaches the last shipment ID).
+    ///
+    /// # Arguments
+    /// * `env` - Execution environment.
+    /// * `admin` - Admin or operator address (auth required).
+    /// * `start_id` - First shipment ID to scan (1-indexed, inclusive).
+    /// * `limit` - Number of shipments to inspect per page; must be in
+    ///   `[1, batch_operation_limit]`.
+    ///
+    /// # Returns
+    /// * `Result<Vec<ConsistencyViolation>, NavinError>` - Violations found in
+    ///   this page. An empty vec means all inspected invariants hold.
+    ///
+    /// # Errors
+    /// * `NavinError::NotInitialized` - If contract is not initialized.
+    /// * `NavinError::Unauthorized` - If caller is not admin or operator.
+    /// * `NavinError::InvalidConfig` - If `limit` is 0 or exceeds the
+    ///   configured `batch_operation_limit`.
+    pub fn check_consistency_violations_paginated(
+        env: Env,
+        admin: Address,
+        start_id: u64,
+        limit: u32,
+    ) -> Result<soroban_sdk::Vec<ConsistencyViolation>, NavinError> {
+        require_initialized(&env)?;
+        admin.require_auth();
+        require_admin_or_operator(&env, &admin)?;
+
+        let max_batch = effective_batch_query_limit(&env);
+        if limit == 0 || limit > max_batch {
+            return Err(NavinError::InvalidConfig);
+        }
+
+        Ok(consistency::check_all_consistency_range(
+            &env,
+            start_id,
+            limit as u64,
+        ))
     }
 
     // =========================================================================

--- a/contracts/shipment/src/test_consistency.rs
+++ b/contracts/shipment/src/test_consistency.rs
@@ -3,8 +3,8 @@ extern crate std;
 use crate::{
     config,
     consistency::{
-        check_all_consistency, check_batch_consistency, check_shipment_invariants,
-        ConsistencyViolation,
+        check_all_consistency, check_all_consistency_range, check_batch_consistency,
+        check_shipment_invariants, ConsistencyViolation, DEFAULT_CONSISTENCY_SAMPLE_LIMIT,
     },
     test_utils,
     types::{ShipmentInput, ShipmentStatus},
@@ -1321,4 +1321,202 @@ fn test_get_version_is_stable_across_repeated_reads() {
     assert_eq!(v3, v4, "repeated get_version must return the same value");
     assert_eq!(v2, 5);
     let _ = v1;
+}
+
+// ── Large-fixture / budget-safety tests (issue #648) ────────────────────────
+
+/// Create N shipments (well above DEFAULT_CONSISTENCY_SAMPLE_LIMIT) and verify
+/// that `check_all_consistency` (the capped variant) inspects exactly
+/// DEFAULT_CONSISTENCY_SAMPLE_LIMIT of them — demonstrating that the call cost
+/// is bounded regardless of total shipment count.
+#[test]
+fn test_large_fixture_check_all_consistency_stays_within_sample_cap() {
+    let (env, client, admin, _) = setup();
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+
+    // Create more shipments than the sample cap so the cap is actually exercised.
+    let total: u64 = (DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64) + 50;
+    for seed in 0..total {
+        create_one(&env, &client, &company, &carrier, (seed % 256) as u8);
+    }
+
+    env.as_contract(&client.address, || {
+        let total_stored = crate::storage::get_shipment_count(&env);
+        assert_eq!(
+            total_stored, total,
+            "all shipments must be registered in storage"
+        );
+
+        // The default (capped) scan must complete without trapping and must
+        // return no violations (all shipments are healthy).
+        let violations = check_all_consistency(&env);
+        assert!(
+            violations.is_empty(),
+            "expected no violations in clean large fixture: {violations:?}"
+        );
+
+        // The scan must have touched at most DEFAULT_CONSISTENCY_SAMPLE_LIMIT
+        // IDs. We verify this indirectly: corrupt shipment ID
+        // DEFAULT_CONSISTENCY_SAMPLE_LIMIT+1 (which is outside the cap window)
+        // and confirm the capped scan does NOT report it.
+        let outside_cap_id = DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64 + 1;
+        crate::storage::set_escrow(&env, outside_cap_id, 999_999);
+
+        let violations_after = check_all_consistency(&env);
+        assert!(
+            !violations_after
+                .iter()
+                .any(|v| v == ConsistencyViolation::EscrowMismatch(outside_cap_id)),
+            "capped scan must NOT report a violation for id={outside_cap_id} \
+             which is beyond the sample window"
+        );
+
+        // Restore to keep remaining assertions clean.
+        let shipment = crate::storage::get_shipment(&env, outside_cap_id).unwrap();
+        crate::storage::set_escrow(&env, outside_cap_id, shipment.escrow_amount);
+    });
+}
+
+/// `check_all_consistency_range` with an explicit page that lands entirely
+/// beyond the sample cap must surface violations for that page — proving the
+/// paginated path reaches IDs the capped default skips.
+#[test]
+fn test_large_fixture_paginated_range_covers_ids_beyond_sample_cap() {
+    let (env, client, admin, _) = setup();
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+
+    let total: u64 = (DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64) + 50;
+    for seed in 0..total {
+        create_one(&env, &client, &company, &carrier, (seed % 256) as u8);
+    }
+
+    env.as_contract(&client.address, || {
+        // Corrupt a shipment that lies beyond the default cap.
+        let target_id = DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64 + 10;
+        crate::storage::set_escrow(&env, target_id, 777_777);
+
+        // Capped default must miss it.
+        let capped = check_all_consistency(&env);
+        assert!(
+            !capped
+                .iter()
+                .any(|v| v == ConsistencyViolation::EscrowMismatch(target_id)),
+            "default capped scan must not see id={target_id}"
+        );
+
+        // Paginated range that covers target_id must find it.
+        let page_start = DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64 + 1;
+        let page_limit = 50_u64;
+        let paged = check_all_consistency_range(&env, page_start, page_limit);
+        assert!(
+            paged
+                .iter()
+                .any(|v| v == ConsistencyViolation::EscrowMismatch(target_id)),
+            "paginated scan starting at {page_start} must detect EscrowMismatch \
+             for id={target_id}: {paged:?}"
+        );
+    });
+}
+
+/// Walking the full shipment set page-by-page must collectively find all
+/// violations that a single unbounded scan would have found.
+#[test]
+fn test_large_fixture_full_paginated_walk_finds_all_violations() {
+    let (env, client, admin, _) = setup();
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+
+    // Create enough shipments to span multiple pages.
+    let total: u64 = (DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64) + 50;
+    for seed in 0..total {
+        create_one(&env, &client, &company, &carrier, (seed % 256) as u8);
+    }
+
+    env.as_contract(&client.address, || {
+        // Corrupt one id in the first half and one in the second half.
+        let id_a: u64 = 5;
+        let id_b: u64 = DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64 + 20;
+        crate::storage::set_escrow(&env, id_a, 11_111);
+        crate::storage::set_escrow(&env, id_b, 22_222);
+
+        // Walk all pages and collect every violation.
+        let page_size: u64 = DEFAULT_CONSISTENCY_SAMPLE_LIMIT as u64;
+        let mut all_violations: soroban_sdk::Vec<ConsistencyViolation> =
+            soroban_sdk::Vec::new(&env);
+        let mut cursor: u64 = 1;
+
+        loop {
+            let page = check_all_consistency_range(&env, cursor, page_size);
+            for v in page.iter() {
+                all_violations.push_back(v);
+            }
+            if cursor + page_size > total {
+                break;
+            }
+            cursor += page_size;
+        }
+
+        assert!(
+            all_violations
+                .iter()
+                .any(|v| v == ConsistencyViolation::EscrowMismatch(id_a)),
+            "paginated walk must find violation for id={id_a}"
+        );
+        assert!(
+            all_violations
+                .iter()
+                .any(|v| v == ConsistencyViolation::EscrowMismatch(id_b)),
+            "paginated walk must find violation for id={id_b}"
+        );
+    });
+}
+
+/// `check_consistency_violations_paginated` exposed via the contract client
+/// must reject a zero limit and a limit exceeding the config cap.
+#[test]
+fn test_paginated_contract_entry_validates_limit() {
+    let (env, client, admin, _) = setup();
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+    client.add_carrier_to_whitelist(&company, &carrier);
+    create_one(&env, &client, &company, &carrier, 1);
+
+    // limit = 0 must be rejected.
+    let err_zero = client.try_check_consistency_violations_paginated(&admin, &1_u64, &0_u32);
+    assert!(
+        err_zero.is_err(),
+        "limit=0 must return an error"
+    );
+
+    // limit > batch_operation_limit must be rejected.
+    let cfg = client.get_contract_config();
+    let too_large = cfg.batch_operation_limit + 1;
+    let err_large =
+        client.try_check_consistency_violations_paginated(&admin, &1_u64, &too_large);
+    assert!(
+        err_large.is_err(),
+        "limit exceeding batch_operation_limit must return an error"
+    );
+
+    // A valid page must succeed and return no violations for a clean state.
+    let ok = client.check_consistency_violations_paginated(&admin, &1_u64, &10_u32);
+    assert!(
+        ok.is_empty(),
+        "valid paginated call on clean state must return no violations"
+    );
+
+    let _ = env;
 }


### PR DESCRIPTION
## Summary

Closes #648.

`consistency::check_all_consistency` (and the inner `check_status_count_consistency`) iterated `1..=total` unbounded -- the same budget-safety hazard fixed for `check_contract_health`. This PR applies the identical sampling/cap strategy used throughout the diagnostics module.

---

## Changes

### consistency.rs
- Added `DEFAULT_CONSISTENCY_SAMPLE_LIMIT = 100` -- matches `diagnostics::DEFAULT_HEALTH_SAMPLE_LIMIT`; cost model is now uniform across all admin scan helpers.
- `check_all_consistency` now delegates to the new range variant (start=1, limit=100) instead of looping `1..=total`.
- New `check_all_consistency_range(start_id, limit)` -- bounded paginated scan; `StatusCountMismatch` is only emitted when the window covers the full shipment set.
- Private `check_status_count_consistency_range` -- bounds the inner O(n) status-counter reconciliation to the same window.

### lib.rs
- Updated `check_consistency_violations` doc to reflect capped-sample behaviour.
- New `check_consistency_violations_paginated(admin, start_id, limit)` -- mirrors `check_contract_health_paginated`: validates `limit` against `effective_batch_query_limit`, returns `InvalidConfig` on bad input.

### test_consistency.rs
- 4 new large-fixture tests (150 shipments, 50 above the cap):
  - `test_large_fixture_check_all_consistency_stays_within_sample_cap` -- proves capped call does not inspect IDs beyond position 100
  - `test_large_fixture_paginated_range_covers_ids_beyond_sample_cap` -- proves paginated path reaches IDs the default scan skips
  - `test_large_fixture_full_paginated_walk_finds_all_violations` -- full page walk collectively detects every seeded violation
  - `test_paginated_contract_entry_validates_limit` -- entry point rejects limit=0 and limit > batch_operation_limit

---

## Acceptance criteria

| Criterion | Status |
|---|---|
| Scan strategy matches codebase sampling pattern | DEFAULT_CONSISTENCY_SAMPLE_LIMIT = 100, same delegation pattern as diagnostics |
| Function scales safely as shipment count grows | check_all_consistency is O(min(n, 100)) |
| Covered by a large-fixture test | 4 new tests with 150-shipment fixtures |