### PR TITLE
fix(archive): clear all per-shipment counters and indexes on archive_shipment (#649)

### DIFF
--- a/contracts/shipment/src/diagnostics.rs
+++ b/contracts/shipment/src/diagnostics.rs
@@ -1,5 +1,5 @@
 use crate::storage;
-use crate::types::ShipmentStatus;
+use crate::types::{DataKey, ShipmentStatus};
 use soroban_sdk::{contracttype, Env, Vec};
 
 /// Reusable response object representing the state of the contract's health.
@@ -78,6 +78,15 @@ pub fn run_system_health_check_range(env: &Env, start_id: u64, limit: u64) -> Sy
                     if !is_terminal && !has_persist && !storage_inconsistencies.contains(id) {
                         storage_inconsistencies.push_back(id);
                     }
+
+                    // Archived (terminal) shipments must not have orphaned
+                    // per-shipment counter or index keys in persistent storage.
+                    // Any present key is a false-positive inconsistency that
+                    // inflates rent costs over time.
+                    let is_archived = !has_persist && is_terminal;
+                    if is_archived && has_orphaned_counters(env, id) && !storage_inconsistencies.contains(id) {
+                        storage_inconsistencies.push_back(id);
+                    }
                 }
                 None => {
                     // Tracking a shipment internally that does not map to any persistent or archived storage
@@ -95,3 +104,78 @@ pub fn run_system_health_check_range(env: &Env, start_id: u64, limit: u64) -> Sy
         storage_inconsistencies,
     }
 }
+
+/// Returns `true` if any per-shipment counter or index key still exists in
+/// persistent storage for a shipment that has already been archived.
+///
+/// Used by `run_system_health_check_range` to detect orphaned keys left
+/// behind by a prior (unfixed) `archive_shipment` call.
+fn has_orphaned_counters(env: &Env, shipment_id: u64) -> bool {
+    // Scalar counter/index keys
+    if storage::has_event_count_entry(env, shipment_id) {
+        return true;
+    }
+    if storage::has_confirmation_hash_entry(env, shipment_id) {
+        return true;
+    }
+    if storage::has_last_status_update_entry(env, shipment_id) {
+        return true;
+    }
+    if storage::has_escrow_entry(env, shipment_id) {
+        return true;
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::MilestoneEventCount(shipment_id))
+    {
+        return true;
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::BreachEventCount(shipment_id))
+    {
+        return true;
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::ActiveSettlement(shipment_id))
+    {
+        return true;
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&storage::escrow_freeze_reason_key(shipment_id))
+    {
+        return true;
+    }
+    // Note count (implies note hashes also exist)
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::ShipmentNoteCount(shipment_id))
+    {
+        return true;
+    }
+    // Evidence count (implies evidence hashes also exist)
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::DisputeEvidenceCount(shipment_id))
+    {
+        return true;
+    }
+    // Recovery record count (implies record entries also exist)
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::RecoveryRecordCount(shipment_id))
+    {
+        return true;
+    }
+    false
+}
+

--- a/contracts/shipment/src/storage.rs
+++ b/contracts/shipment/src/storage.rs
@@ -1548,10 +1548,49 @@ pub fn archive_shipment(env: &Env, shipment_id: u64, shipment: &Shipment) {
         .temporary()
         .set(&DataKey::ArchivedShipment(shipment_id), shipment);
 
-    // Remove from persistent storage
+    // Remove primary shipment record from persistent storage
     env.storage()
         .persistent()
         .remove(&DataKey::Shipment(shipment_id));
+
+    // ── Clean up all per-shipment persistent counters and indexes ────────────
+    // Leaving these behind inflates check_contract_health's
+    // storage_inconsistencies list over time (#649).
+
+    // Escrow (always zero by the time a terminal-state shipment is archived,
+    // but the key itself persists until explicitly removed).
+    remove_escrow(env, shipment_id);
+
+    // Confirmation hash (written on confirm_delivery).
+    remove_confirmation_hash(env, shipment_id);
+
+    // Rate-limit timestamp for status updates.
+    remove_last_status_update(env, shipment_id);
+
+    // General-purpose event counter.
+    remove_event_count(env, shipment_id);
+
+    // Milestone and breach event counters.
+    remove_milestone_event_count(env, shipment_id);
+    remove_breach_event_count(env, shipment_id);
+
+    // Escrow freeze reason (written when escrow is frozen during dispute/pause).
+    remove_escrow_freeze_reason(env, shipment_id);
+
+    // Active settlement pointer (written by settlement module).
+    clear_active_settlement(env, shipment_id);
+
+    // Notes: remove every indexed entry then the count key.
+    purge_shipment_notes(env, shipment_id);
+
+    // Dispute evidence: remove every indexed entry then the count key.
+    purge_dispute_evidence(env, shipment_id);
+
+    // Recovery records: remove every indexed entry then the count key.
+    purge_recovery_records(env, shipment_id);
+
+    // IoT status hashes: one entry per ShipmentStatus variant.
+    purge_status_hashes(env, shipment_id);
 }
 
 /// Get an archived shipment from temporary storage.
@@ -1594,7 +1633,118 @@ pub fn is_shipment_archived(env: &Env, shipment_id: u64) -> bool {
         .has(&DataKey::ArchivedShipment(shipment_id))
 }
 
-// ============= Shipment Note Storage Functions =============
+// ============= Per-Shipment Cleanup Helpers (used by archive_shipment) =============
+
+/// Remove the confirmation hash for a shipment from persistent storage.
+pub fn remove_confirmation_hash(env: &Env, shipment_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&confirmation_hash_key(shipment_id));
+}
+
+/// Remove the last-status-update timestamp for a shipment from persistent storage.
+pub fn remove_last_status_update(env: &Env, shipment_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::LastStatusUpdate(shipment_id));
+}
+
+/// Remove the event count for a shipment from persistent storage.
+pub fn remove_event_count(env: &Env, shipment_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::EventCount(shipment_id));
+}
+
+/// Remove the milestone event count for a shipment from persistent storage.
+pub fn remove_milestone_event_count(env: &Env, shipment_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::MilestoneEventCount(shipment_id));
+}
+
+/// Remove the breach event count for a shipment from persistent storage.
+pub fn remove_breach_event_count(env: &Env, shipment_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::BreachEventCount(shipment_id));
+}
+
+/// Remove the escrow freeze reason for a shipment from persistent storage.
+pub fn remove_escrow_freeze_reason(env: &Env, shipment_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&escrow_freeze_reason_key(shipment_id));
+}
+
+/// Remove all note hashes and the note count for a shipment from persistent storage.
+pub fn purge_shipment_notes(env: &Env, shipment_id: u64) {
+    let count = get_note_count(env, shipment_id);
+    for i in 0..count {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ShipmentNote(shipment_id, i));
+    }
+    if count > 0 {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ShipmentNoteCount(shipment_id));
+    }
+}
+
+/// Remove all evidence hashes and the evidence count for a shipment from persistent storage.
+pub fn purge_dispute_evidence(env: &Env, shipment_id: u64) {
+    let count = get_evidence_count(env, shipment_id);
+    for i in 0..count {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::DisputeEvidence(shipment_id, i));
+    }
+    if count > 0 {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::DisputeEvidenceCount(shipment_id));
+    }
+}
+
+/// Remove all recovery records and the record count for a shipment from persistent storage.
+pub fn purge_recovery_records(env: &Env, shipment_id: u64) {
+    let count = get_recovery_record_count(env, shipment_id);
+    for i in 0..count {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RecoveryRecord(shipment_id, i));
+    }
+    if count > 0 {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RecoveryRecordCount(shipment_id));
+    }
+}
+
+/// Remove all IoT status hash entries for a shipment from persistent storage.
+///
+/// One entry may exist for each `ShipmentStatus` variant, written during
+/// `update_status` calls that supply a data hash.
+pub fn purge_status_hashes(env: &Env, shipment_id: u64) {
+    use ShipmentStatus::*;
+    for status in [
+        Created,
+        InTransit,
+        AtCheckpoint,
+        PartiallyDelivered,
+        Delivered,
+        Disputed,
+        Cancelled,
+    ] {
+        let key = DataKey::StatusHash(shipment_id, status);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().remove(&key);
+        }
+    }
+}
+
+
 
 /// Get the total number of notes appended to a shipment.
 pub fn get_note_count(env: &Env, shipment_id: u64) -> u32 {

--- a/contracts/shipment/src/test_finalization.rs
+++ b/contracts/shipment/src/test_finalization.rs
@@ -453,3 +453,226 @@ fn test_recovery_history_logging() {
     assert_eq!(rec2.admin, admin);
     assert_eq!(rec2.reason_hash, reason2);
 }
+
+// ── #649: No orphaned counters/indexes after archive_shipment ────────────────
+
+/// Archive a cancelled shipment that has notes, dispute evidence, and a
+/// recovery record, then assert:
+///   1. The shipment is still readable from temporary (archived) storage.
+///   2. No per-shipment counter or index key survives in persistent storage.
+///   3. `check_contract_health` reports zero storage inconsistencies.
+#[test]
+fn test_archive_clears_all_per_shipment_counters() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[0xABu8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+    client.add_carrier(&admin, &carrier);
+
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &Vec::new(&env),
+        &deadline,
+    );
+
+    // Add two notes via the public API
+    let note0 = BytesN::from_array(&env, &[0x11u8; 32]);
+    let note1 = BytesN::from_array(&env, &[0x22u8; 32]);
+    client.append_note_hash(&company, &shipment_id, &note0);
+    client.append_note_hash(&company, &shipment_id, &note1);
+    assert_eq!(client.get_note_count(&shipment_id), 2);
+
+    // Inject dispute evidence and recovery records directly via storage so
+    // we don't need to go through the Disputed state machine path.  This
+    // mirrors what test_detect_storage_inconsistencies does and is the
+    // standard approach for seeding raw storage in this test suite.
+    let cid = client.address.clone();
+    env.as_contract(&cid, || {
+        use crate::types::{DataKey, RecoveryActionType, RecoveryRecord};
+
+        // Two evidence hashes (index 0 and 1)
+        let evidence0 = BytesN::from_array(&env, &[0x44u8; 32]);
+        let evidence1 = BytesN::from_array(&env, &[0x55u8; 32]);
+        env.storage().persistent().set(&DataKey::DisputeEvidence(shipment_id, 0), &evidence0);
+        env.storage().persistent().set(&DataKey::DisputeEvidence(shipment_id, 1), &evidence1);
+        env.storage().persistent().set(&DataKey::DisputeEvidenceCount(shipment_id), &2u32);
+
+        // One recovery record (index 0)
+        let record = RecoveryRecord {
+            action_type: RecoveryActionType::RecoverShipment,
+            admin: admin.clone(),
+            reason_hash: BytesN::from_array(&env, &[0x77u8; 32]),
+            timestamp: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&DataKey::RecoveryRecord(shipment_id, 0), &record);
+        env.storage().persistent().set(&DataKey::RecoveryRecordCount(shipment_id), &1u32);
+    });
+
+    assert_eq!(client.get_dispute_evidence_count(&shipment_id), 2);
+    assert_eq!(client.get_recovery_record_count(&shipment_id), 1);
+
+    // Cancel to reach a terminal state
+    let cancel_hash = BytesN::from_array(&env, &[0x66u8; 32]);
+    client.cancel_shipment(&company, &shipment_id, &cancel_hash);
+    assert_eq!(client.get_shipment(&shipment_id).status, ShipmentStatus::Cancelled);
+
+    // Sanity: health is clean before archival
+    let pre_health = client.check_contract_health(&admin);
+    assert_eq!(
+        pre_health.storage_inconsistencies.len(),
+        0,
+        "unexpected pre-archive inconsistencies: {:?}",
+        pre_health.storage_inconsistencies
+    );
+
+    // Archive the shipment — this is the operation under test
+    client.archive_shipment(&admin, &shipment_id);
+
+    // 1. Shipment must still be readable from temporary (archived) storage
+    let archived = client.get_shipment(&shipment_id);
+    assert_eq!(archived.id, shipment_id);
+    assert_eq!(archived.status, ShipmentStatus::Cancelled);
+
+    // 2. Verify no orphaned persistent keys remain by inspecting storage directly
+    env.as_contract(&cid, || {
+        use crate::types::DataKey;
+
+        // Primary shipment record must be gone
+        assert!(
+            !env.storage().persistent().has(&DataKey::Shipment(shipment_id)),
+            "Shipment key must be removed after archive"
+        );
+
+        // Counters / scalar keys
+        assert!(
+            !env.storage().persistent().has(&DataKey::EventCount(shipment_id)),
+            "EventCount must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::MilestoneEventCount(shipment_id)),
+            "MilestoneEventCount must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::BreachEventCount(shipment_id)),
+            "BreachEventCount must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::LastStatusUpdate(shipment_id)),
+            "LastStatusUpdate must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::ConfirmationHash(shipment_id)),
+            "ConfirmationHash must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::Escrow(shipment_id)),
+            "Escrow key must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::EscrowFreezeReasonByShipment(shipment_id)),
+            "EscrowFreezeReasonByShipment must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::ActiveSettlement(shipment_id)),
+            "ActiveSettlement must be cleared after archive"
+        );
+
+        // Note count + per-index entries
+        assert!(
+            !env.storage().persistent().has(&DataKey::ShipmentNoteCount(shipment_id)),
+            "ShipmentNoteCount must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::ShipmentNote(shipment_id, 0)),
+            "ShipmentNote[0] must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::ShipmentNote(shipment_id, 1)),
+            "ShipmentNote[1] must be cleared after archive"
+        );
+
+        // Evidence count + per-index entries
+        assert!(
+            !env.storage().persistent().has(&DataKey::DisputeEvidenceCount(shipment_id)),
+            "DisputeEvidenceCount must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::DisputeEvidence(shipment_id, 0)),
+            "DisputeEvidence[0] must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::DisputeEvidence(shipment_id, 1)),
+            "DisputeEvidence[1] must be cleared after archive"
+        );
+
+        // Recovery record count + per-index entries
+        assert!(
+            !env.storage().persistent().has(&DataKey::RecoveryRecordCount(shipment_id)),
+            "RecoveryRecordCount must be cleared after archive"
+        );
+        assert!(
+            !env.storage().persistent().has(&DataKey::RecoveryRecord(shipment_id, 0)),
+            "RecoveryRecord[0] must be cleared after archive"
+        );
+    });
+
+    // 3. check_contract_health must report no false-positive inconsistencies
+    let post_health = client.check_contract_health(&admin);
+    assert_eq!(
+        post_health.storage_inconsistencies.len(),
+        0,
+        "check_contract_health must report no inconsistencies after archive: {:?}",
+        post_health.storage_inconsistencies
+    );
+}
+
+/// Archiving a shipment that has *no* optional counters (no notes, evidence,
+/// or recovery records) must still succeed cleanly — the purge helpers are
+/// no-ops when counts are zero.
+#[test]
+fn test_archive_with_no_optional_counters_is_clean() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[0x01u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+
+    client.initialize(&admin, &token_contract);
+    client.add_company(&admin, &company);
+
+    let shipment_id = client.create_shipment(
+        &company,
+        &receiver,
+        &carrier,
+        &data_hash,
+        &Vec::new(&env),
+        &deadline,
+    );
+
+    client.cancel_shipment(&company, &shipment_id, &data_hash);
+
+    // Archive with no extra state accumulated
+    client.archive_shipment(&admin, &shipment_id);
+
+    // Shipment is readable
+    let archived = client.get_shipment(&shipment_id);
+    assert_eq!(archived.id, shipment_id);
+
+    // No inconsistencies
+    let health = client.check_contract_health(&admin);
+    assert_eq!(
+        health.storage_inconsistencies.len(),
+        0,
+        "no inconsistencies expected after bare archive: {:?}",
+        health.storage_inconsistencies
+    );
+}


### PR DESCRIPTION
## Summary

Closes #649.

`archive_shipment` previously only removed `DataKey::Shipment` from persistent storage. Every other per-shipment key was left orphaned, inflating state-rent costs and causing `check_contract_health` to report false-positive `storage_inconsistencies` for every archived shipment.

## Root cause

`storage::archive_shipment` wrote `ArchivedShipment` to temporary storage and removed `DataKey::Shipment`, but never touched the 15+ other persistent keys scoped to the same `shipment_id`.

## What changed

**`storage.rs`**
- Added remove helpers for every orphaned key family: `remove_confirmation_hash`, `remove_last_status_update`, `remove_event_count`, `remove_milestone_event_count`, `remove_breach_event_count`, `remove_escrow_freeze_reason`
- Added bulk-purge helpers that iterate indexed entries then remove their count key: `purge_shipment_notes`, `purge_dispute_evidence`, `purge_recovery_records`, `purge_status_hashes`  
- Updated `archive_shipment` to call all of the above after writing `ArchivedShipment`  

**`diagnostics.rs`**
- Added private `has_orphaned_counters` helper  
- `run_system_health_check_range` now flags archived shipments with surviving persistent counter keys as `storage_inconsistencies`  

**`test_finalization.rs`**
- `test_archive_clears_all_per_shipment_counters`: archives a shipment that has notes, injected evidence, and an injected recovery record; asserts every persistent key is gone post-archive and `check_contract_health` reports 0 inconsistencies  
- `test_archive_with_no_optional_counters_is_clean`: confirms the purge helpers are safe no-ops when all counts are zero  

## Acceptance criteria

- [x] Archiving leaves no orphaned counters or indexes
- [x] `check_contract_health` reports no false-positive inconsistencies after archival
- [x] Covered by two dedicated tests