### PR TITLE
fix(shipment): add pause guards and error boundary tests

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -4386,6 +4386,7 @@ impl NavinShipment {
     /// ```
     pub fn release_escrow(env: Env, caller: Address, shipment_id: u64) -> Result<(), NavinError> {
         require_initialized(&env)?;
+        require_not_paused(&env)?;
         caller.require_auth();
 
         with_reentrancy_lock(&env, || {
@@ -4475,6 +4476,7 @@ impl NavinShipment {
     /// ```
     pub fn refund_escrow(env: Env, caller: Address, shipment_id: u64) -> Result<(), NavinError> {
         require_initialized(&env)?;
+        require_not_paused(&env)?;
         caller.require_auth();
 
         with_reentrancy_lock(&env, || {

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -2029,6 +2029,10 @@ impl NavinShipment {
         validate_milestones(&env, &payment_milestones)?;
         validate_hash(&data_hash)?;
 
+        if sender == receiver || sender == carrier || receiver == carrier {
+            return Err(NavinError::InvalidShipmentParticipants);
+        }
+
         // Idempotency: reject duplicate (sender, data_hash) within the window.
         let mut payload = soroban_sdk::Bytes::new(&env);
         payload.append(&sender.clone().to_xdr(&env));

--- a/contracts/shipment/src/test.rs
+++ b/contracts/shipment/src/test.rs
@@ -370,6 +370,48 @@ fn test_create_shipment_unauthorized() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #57)")]
+fn test_create_shipment_rejects_sender_equals_receiver() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+    let company = Address::generate(&env);
+    let carrier = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[7u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+    client.add_company(&admin, &company);
+    // sender and receiver are the same address — must be rejected
+    client.create_shipment(
+        &company,
+        &company,
+        &carrier,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #57)")]
+fn test_create_shipment_rejects_sender_equals_carrier() {
+    let (env, client, admin, token_contract) = setup_shipment_env();
+    client.initialize(&admin, &token_contract);
+    let company = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let data_hash = BytesN::from_array(&env, &[8u8; 32]);
+    let deadline = env.ledger().timestamp() + 3600;
+    client.add_company(&admin, &company);
+    // sender and carrier are the same address — must be rejected
+    client.create_shipment(
+        &company,
+        &receiver,
+        &company,
+        &data_hash,
+        &soroban_sdk::Vec::new(&env),
+        &deadline,
+    );
+}
+
+#[test]
 fn test_multiple_shipments_have_unique_ids() {
     let (env, client, admin, token_contract) = setup_shipment_env();
     let company = Address::generate(&env);

--- a/contracts/shipment/src/test_escrow_arithmetic.rs
+++ b/contracts/shipment/src/test_escrow_arithmetic.rs
@@ -413,3 +413,101 @@ mod total_escrow_volume_overflow {
         );
     }
 }
+
+// =============================================================================
+// Issue #617 — InvalidAmount boundary tests
+// =============================================================================
+//
+// These tests verify that `NavinError::InvalidAmount` (code #14) is returned
+// when callers supply out-of-range arguments:
+//   • `set_platform_fee` when fee_bps > 1000
+//   • `confirm_partial_delivery` when release_percent == 0 or > 100
+
+mod invalid_amount_validation {
+    extern crate std;
+
+    use crate::errors::NavinError;
+    use crate::{NavinShipment, NavinShipmentClient};
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+    #[soroban_sdk::contract]
+    struct MockPlatformToken;
+
+    #[soroban_sdk::contractimpl]
+    impl MockPlatformToken {
+        pub fn decimals(_env: Env) -> u32 {
+            7
+        }
+        pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    }
+
+    fn setup() -> (Env, NavinShipmentClient<'static>, Address) {
+        let (env, admin) = crate::test_utils::setup_env();
+        let token = env.register(MockPlatformToken, ());
+        let cid = env.register(NavinShipment, ());
+        let client = NavinShipmentClient::new(&env, &cid);
+        client.initialize(&admin, &token);
+        (env, client, admin)
+    }
+
+    fn check_invalid_amount(result: Result<Result<(), soroban_sdk::Error>, soroban_sdk::InvokeError>) {
+        let expected = soroban_sdk::Error::from_contract_error(NavinError::InvalidAmount as u32);
+        match result {
+            Ok(Err(e)) => assert_eq!(e, expected, "must return InvalidAmount (code #14)"),
+            Err(e) => {
+                let s = std::format!("{:?}", e);
+                assert!(
+                    s.contains("InvalidAmount") || s.contains("Code(14)"),
+                    "expected InvalidAmount in host error, got {:?}", s
+                );
+            }
+            Ok(Ok(_)) => panic!("expected InvalidAmount error but call succeeded"),
+        }
+    }
+
+    /// `set_platform_fee` with fee_bps = 1001 must return InvalidAmount.
+    #[test]
+    fn test_set_platform_fee_above_max_bps_returns_invalid_amount() {
+        let (env, client, admin) = setup();
+        env.mock_all_auths();
+        let treasury = Address::generate(&env);
+        let result = client.try_set_platform_fee(&admin, &1001u32, &treasury);
+        check_invalid_amount(result);
+    }
+
+    /// `set_platform_fee` with fee_bps = 1000 must succeed (boundary is inclusive).
+    #[test]
+    fn test_set_platform_fee_at_max_bps_succeeds() {
+        let (env, client, admin) = setup();
+        env.mock_all_auths();
+        let treasury = Address::generate(&env);
+        let result = client.try_set_platform_fee(&admin, &1000u32, &treasury);
+        assert!(
+            matches!(result, Ok(Ok(()))),
+            "fee_bps=1000 must succeed (boundary)"
+        );
+    }
+
+    /// `confirm_partial_delivery` with release_percent = 0 must return InvalidAmount.
+    /// The guard fires before the shipment lookup, so no shipment is needed.
+    #[test]
+    fn test_confirm_partial_delivery_zero_percent_returns_invalid_amount() {
+        let (env, client, _admin) = setup();
+        env.mock_all_auths();
+        let receiver = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let result = client.try_confirm_partial_delivery(&receiver, &1u64, &hash, &0u32);
+        check_invalid_amount(result);
+    }
+
+    /// `confirm_partial_delivery` with release_percent = 101 must return InvalidAmount.
+    #[test]
+    fn test_confirm_partial_delivery_over_hundred_percent_returns_invalid_amount() {
+        let (env, client, _admin) = setup();
+        env.mock_all_auths();
+        let receiver = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[2u8; 32]);
+        let result = client.try_confirm_partial_delivery(&receiver, &1u64, &hash, &101u32);
+        check_invalid_amount(result);
+    }
+}

--- a/contracts/shipment/src/test_pause.rs
+++ b/contracts/shipment/src/test_pause.rs
@@ -806,6 +806,141 @@ mod tests {
         assert_eq!(err, crate::NavinError::ContractPaused);
     }
 
+    // ── release_escrow pause guard (#626) ────────────────────────────────────
+
+    /// release_escrow must be blocked when the contract is paused.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #43)")]
+    fn test_release_escrow_fails_when_paused() {
+        let (env, client, admin, token_contract) = setup_test_env();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        let receiver = Address::generate(&env);
+
+        client.initialize(&admin, &token_contract);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let milestones = Vec::new(&env);
+        let deadline = future_deadline(&env, 86400);
+
+        let shipment_id =
+            client.create_shipment(&company, &receiver, &carrier, &hash, &milestones, &deadline);
+
+        // Advance to Delivered state
+        client.update_status(
+            &carrier,
+            &shipment_id,
+            &ShipmentStatus::InTransit,
+            &BytesN::from_array(&env, &[2u8; 32]),
+        );
+        client.update_status(
+            &carrier,
+            &shipment_id,
+            &ShipmentStatus::Delivered,
+            &BytesN::from_array(&env, &[3u8; 32]),
+        );
+
+        // Pause the contract, then try to release escrow.
+        client.pause(&admin);
+        client.release_escrow(&receiver, &shipment_id);
+    }
+
+    /// release_escrow succeeds normally when the contract is unpaused.
+    #[test]
+    fn test_release_escrow_succeeds_when_unpaused() {
+        let (env, client, admin, token_contract) = setup_test_env();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        let receiver = Address::generate(&env);
+
+        client.initialize(&admin, &token_contract);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let milestones = Vec::new(&env);
+        let deadline = future_deadline(&env, 86400);
+
+        let shipment_id =
+            client.create_shipment(&company, &receiver, &carrier, &hash, &milestones, &deadline);
+
+        client.update_status(
+            &carrier,
+            &shipment_id,
+            &ShipmentStatus::InTransit,
+            &BytesN::from_array(&env, &[2u8; 32]),
+        );
+        client.update_status(
+            &carrier,
+            &shipment_id,
+            &ShipmentStatus::Delivered,
+            &BytesN::from_array(&env, &[3u8; 32]),
+        );
+
+        // Pause then immediately unpause — release should succeed.
+        client.pause(&admin);
+        client.unpause(&admin);
+
+        // Should not panic.
+        client.release_escrow(&receiver, &shipment_id);
+    }
+
+    // ── refund_escrow pause guard (#627) ─────────────────────────────────────
+
+    /// refund_escrow must be blocked when the contract is paused.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #43)")]
+    fn test_refund_escrow_fails_when_paused() {
+        let (env, client, admin, token_contract) = setup_test_env();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        let receiver = Address::generate(&env);
+
+        client.initialize(&admin, &token_contract);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let milestones = Vec::new(&env);
+        let deadline = future_deadline(&env, 86400);
+
+        let shipment_id =
+            client.create_shipment(&company, &receiver, &carrier, &hash, &milestones, &deadline);
+
+        // Pause the contract, then try to refund.
+        client.pause(&admin);
+        client.refund_escrow(&company, &shipment_id);
+    }
+
+    /// refund_escrow succeeds normally when the contract is unpaused.
+    #[test]
+    fn test_refund_escrow_succeeds_when_unpaused() {
+        let (env, client, admin, token_contract) = setup_test_env();
+        let company = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        let receiver = Address::generate(&env);
+
+        client.initialize(&admin, &token_contract);
+        client.add_company(&admin, &company);
+        client.add_carrier(&admin, &carrier);
+
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let milestones = Vec::new(&env);
+        let deadline = future_deadline(&env, 86400);
+
+        let shipment_id =
+            client.create_shipment(&company, &receiver, &carrier, &hash, &milestones, &deadline);
+
+        // Pause then unpause — refund on a Created shipment should succeed.
+        client.pause(&admin);
+        client.unpause(&admin);
+
+        // Should not panic (shipment is in Created status, refund is valid).
+        client.refund_escrow(&company, &shipment_id);
+    }
+
     /// Test: Circuit breaker state persists across pause/unpause cycles.
     /// Verify that pause/unpause doesn't reset circuit breaker state.
     #[test]


### PR DESCRIPTION
## Summary

- Added `require_not_paused(&env)?` guard to `release_escrow` and `refund_escrow` so both functions correctly reject calls when the contract is paused
- Added pause/unpause test coverage in `test_pause.rs` verifying `ContractPaused` (error code #43) is returned from both functions when paused, and that they succeed when unpaused
- Extended `test_counter_overflow.rs` with explicit `CounterOverflow` (error code #11) assertions when `ShipmentCount` is seeded to `u64::MAX`
- Added `invalid_amount_validation` module in `test_escrow_arithmetic.rs` covering `NavinError::InvalidAmount` (code #14) for `set_platform_fee` (`fee_bps > 1000`) and `confirm_partial_delivery` (`release_percent == 0` or `> 100`)
- Wired up `InvalidShipmentParticipants` (error code #57) in `create_shipment` — added distinctness guard rejecting sender==receiver, sender==carrier, and receiver==carrier; covered by two new `#[should_panic]` tests

Closes #627
Closes #626
Closes #618
Closes #617
