### PR TITLE
Fix/recovery wrappers require initialized 677 680

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -6434,6 +6434,7 @@ impl NavinShipment {
         target_status: ShipmentStatus,
         reason_hash: BytesN<32>,
     ) -> Result<(), NavinError> {
+        require_initialized(&env)?;
         recovery::recover_shipment(&env, &admin, shipment_id, target_status, &reason_hash)
     }
 

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -6444,6 +6444,7 @@ impl NavinShipment {
         shipment_id: u64,
         reason_hash: BytesN<32>,
     ) -> Result<(), NavinError> {
+        require_initialized(&env)?;
         recovery::unlock_escrow(&env, &admin, shipment_id, &reason_hash)
     }
 

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -6454,6 +6454,7 @@ impl NavinShipment {
         shipment_id: u64,
         reason_hash: BytesN<32>,
     ) -> Result<(), NavinError> {
+        require_initialized(&env)?;
         recovery::clear_finalization(&env, &admin, shipment_id, &reason_hash)
     }
 

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -6465,6 +6465,7 @@ impl NavinShipment {
         previous_status: ShipmentStatus,
         reason_hash: BytesN<32>,
     ) -> Result<(), NavinError> {
+        require_initialized(&env)?;
         recovery::rollback_on_external_failure(
             &env,
             &admin,

--- a/contracts/shipment/src/test_finalization.rs
+++ b/contracts/shipment/src/test_finalization.rs
@@ -711,3 +711,14 @@ fn test_clear_finalization_before_initialize_returns_error() {
         Err(Ok(crate::NavinError::NotInitialized))
     );
 }
+
+#[test]
+fn test_rollback_on_external_failure_before_initialize_returns_error() {
+    let (env, client, admin, _token) = setup_shipment_env();
+    let reason = BytesN::from_array(&env, &[0xC6; 32]);
+
+    assert_eq!(
+        client.try_rollback_on_external_failure(&admin, &1u64, &ShipmentStatus::Created, &reason),
+        Err(Ok(crate::NavinError::NotInitialized))
+    );
+}

--- a/contracts/shipment/src/test_finalization.rs
+++ b/contracts/shipment/src/test_finalization.rs
@@ -700,3 +700,14 @@ fn test_unlock_escrow_before_initialize_returns_error() {
         Err(Ok(crate::NavinError::NotInitialized))
     );
 }
+
+#[test]
+fn test_clear_finalization_before_initialize_returns_error() {
+    let (env, client, admin, _token) = setup_shipment_env();
+    let reason = BytesN::from_array(&env, &[0xC5; 32]);
+
+    assert_eq!(
+        client.try_clear_finalization(&admin, &1u64, &reason),
+        Err(Ok(crate::NavinError::NotInitialized))
+    );
+}

--- a/contracts/shipment/src/test_finalization.rs
+++ b/contracts/shipment/src/test_finalization.rs
@@ -689,3 +689,14 @@ fn test_recover_shipment_before_initialize_returns_error() {
         Err(Ok(crate::NavinError::NotInitialized))
     );
 }
+
+#[test]
+fn test_unlock_escrow_before_initialize_returns_error() {
+    let (env, client, admin, _token) = setup_shipment_env();
+    let reason = BytesN::from_array(&env, &[0xC4; 32]);
+
+    assert_eq!(
+        client.try_unlock_escrow(&admin, &1u64, &reason),
+        Err(Ok(crate::NavinError::NotInitialized))
+    );
+}

--- a/contracts/shipment/src/test_finalization.rs
+++ b/contracts/shipment/src/test_finalization.rs
@@ -676,3 +676,16 @@ fn test_archive_with_no_optional_counters_is_clean() {
         health.storage_inconsistencies
     );
 }
+
+// ── #677-#680: recovery wrappers return NotInitialized instead of panicking ──
+
+#[test]
+fn test_recover_shipment_before_initialize_returns_error() {
+    let (env, client, admin, _token) = setup_shipment_env();
+    let reason = BytesN::from_array(&env, &[0xC3; 32]);
+
+    assert_eq!(
+        client.try_recover_shipment(&admin, &1u64, &ShipmentStatus::Cancelled, &reason),
+        Err(Ok(crate::NavinError::NotInitialized))
+    );
+}


### PR DESCRIPTION
## Summary

The four recovery wrappers in the shipment contract delegate straight into
`recovery::*`, which calls `storage::get_admin`. That helper does a bare
`.unwrap()` on instance storage, so calling any of these entrypoints before
`initialize()` panicked the transaction instead of returning a clean error —
inconsistent with essentially every other admin function on the contract.

This adds the missing `require_initialized(&env)?` guard to each wrapper, so a
pre-init call now returns `NotInitialized` like the rest of the surface.

## Changes

`contracts/shipment/src/lib.rs`
- `recover_shipment` — added `require_initialized` check
- `unlock_escrow` — added `require_initialized` check
- `clear_finalization` — added `require_initialized` check
- `rollback_on_external_failure` — added `require_initialized` check

`contracts/shipment/src/test_finalization.rs`
- Added one pre-initialization test per entrypoint, asserting
  `Err(Ok(NavinError::NotInitialized))` rather than a panic.

The guard runs before any storage read or delegation, so post-init behaviour is
untouched — existing recovery tests (e.g. `test_recovery_history_logging`)
exercise the same paths after `initialize()` and are unaffected.

## Notes

Each issue is addressed in its own commit. No changes to `recovery.rs` or
`storage.rs` were needed — the guard belongs at the contract boundary, matching
how the rest of the contract handles this.

Closes #677
Closes #678
Closes #679
Closes #680
